### PR TITLE
Add term mapping for sectors and industries

### DIFF
--- a/Config/term_mapping.json
+++ b/Config/term_mapping.json
@@ -1,0 +1,7 @@
+{
+  "Technology": ["Tech", "Information Technology", "IT"],
+  "Financials": ["Finance", "Financial Services"],
+  "Healthcare": ["Health Care", "Medical"],
+  "Consumer Discretionary": ["Consumer Cyclical"],
+  "Consumer Staples": ["Consumer Defensive"]
+}

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,3 +12,4 @@ openbb
 openbb[all]
 matplotlib
 yfinance
+openai

--- a/src/group_analysis/group_analysis.py
+++ b/src/group_analysis/group_analysis.py
@@ -25,6 +25,7 @@ import os
 import sys
 import pandas as pd
 import yfinance as yf
+from term_mapper import resolve_term
 
 PORTFOLIO_FILE = "portfolio.xlsx"
 GROUPS_FILE = "groups.xlsx"
@@ -97,8 +98,8 @@ def fetch_from_yfinance(ticker: str) -> dict:
     return {
         "Ticker": ticker.upper(),
         "Name": info.get("longName", ""),
-        "Sector": info.get("sector", ""),
-        "Industry": info.get("industry", ""),
+        "Sector": resolve_term(info.get("sector", "")),
+        "Industry": resolve_term(info.get("industry", "")),
         "Current Price": info.get("currentPrice", pd.NA),
         "Market Cap": info.get("marketCap", pd.NA),
         "PE Ratio": info.get("trailingPE", pd.NA),
@@ -121,6 +122,11 @@ def prompt_manual_entry(ticker: str) -> dict:
                 data[field] = pd.NA
         else:
             data[field] = val if val else ""
+
+    if "Sector" in data:
+        data["Sector"] = resolve_term(data["Sector"])
+    if "Industry" in data:
+        data["Industry"] = resolve_term(data["Industry"])
     return data
 
 

--- a/src/portfolio_manager/portfolio_manager.py
+++ b/src/portfolio_manager/portfolio_manager.py
@@ -19,6 +19,7 @@ import os
 import sys
 import pandas as pd
 import yfinance as yf
+from term_mapper import resolve_term
 
 PORTFOLIO_FILE = "portfolio.xlsx"
 COLUMNS = [
@@ -82,6 +83,12 @@ def prompt_manual_entry(ticker: str) -> dict:
                 data[field] = pd.NA
         else:
             data[field] = val if val else ""
+
+    # Normalize sector/industry via term mapper
+    if "Sector" in data:
+        data["Sector"] = resolve_term(data["Sector"])
+    if "Industry" in data:
+        data["Industry"] = resolve_term(data["Industry"])
     return data
 
 
@@ -100,8 +107,8 @@ def fetch_from_yfinance(ticker: str) -> dict:
     data = {
         "Ticker": ticker.upper(),
         "Name": info.get("longName", ""),
-        "Sector": info.get("sector", ""),
-        "Industry": info.get("industry", ""),
+        "Sector": resolve_term(info.get("sector", "")),
+        "Industry": resolve_term(info.get("industry", "")),
         "Current Price": info.get("currentPrice", pd.NA),
         "Market Cap": info.get("marketCap", pd.NA),
         "PE Ratio": info.get("trailingPE", pd.NA),

--- a/src/term_mapper.py
+++ b/src/term_mapper.py
@@ -1,0 +1,105 @@
+import json
+import os
+from typing import Dict, List, Optional
+
+try:
+    import openai
+except Exception:
+    openai = None
+
+
+MAPPING_FILE = os.path.join(os.path.dirname(__file__), '..', 'Config', 'term_mapping.json')
+MAPPING_FILE = os.path.abspath(MAPPING_FILE)
+
+
+def load_mapping() -> Dict[str, List[str]]:
+    if not os.path.isfile(MAPPING_FILE):
+        return {}
+    with open(MAPPING_FILE, 'r', encoding='utf-8') as f:
+        return json.load(f)
+
+
+def save_mapping(mapping: Dict[str, List[str]]):
+    os.makedirs(os.path.dirname(MAPPING_FILE), exist_ok=True)
+    with open(MAPPING_FILE, 'w', encoding='utf-8') as f:
+        json.dump(mapping, f, indent=2)
+
+
+def _normalize(text: str) -> str:
+    return text.strip().lower()
+
+
+def add_alias(canonical: str, alias: str):
+    mapping = load_mapping()
+    canonical_norm = canonical.strip()
+    alias_norm = alias.strip()
+    if not canonical_norm or not alias_norm:
+        return
+    aliases = mapping.get(canonical_norm, [])
+    if alias_norm not in aliases:
+        aliases.append(alias_norm)
+        mapping[canonical_norm] = aliases
+        save_mapping(mapping)
+
+
+def _suggest_with_openai(term: str, options: List[str]) -> Optional[str]:
+    if openai is None or not os.getenv('OPENAI_API_KEY'):
+        return None
+    try:
+        openai.api_key = os.getenv('OPENAI_API_KEY')
+        prompt = (
+            "You are an assistant that maps financial sector or industry terms to a canonical term. "
+            f"Given the term '{term}', choose the best match from the following options: {', '.join(options)}. "
+            "Respond with only the best matching option or 'Unknown'."
+        )
+        response = openai.ChatCompletion.create(
+            model="gpt-3.5-turbo",
+            messages=[{"role": "user", "content": prompt}],
+            max_tokens=6
+        )
+        choice = response.choices[0].message.content.strip()
+        if choice and choice != 'Unknown':
+            return choice
+    except Exception:
+        return None
+    return None
+
+
+def resolve_term(term: str) -> str:
+    """Return canonical term for given term. If unknown, ask user."""
+    if not term:
+        return term
+    mapping = load_mapping()
+    norm = _normalize(term)
+    # direct match
+    for canonical, aliases in mapping.items():
+        if norm == _normalize(canonical) or norm in [_normalize(a) for a in aliases]:
+            return canonical
+    # not found; try openai suggestion
+    suggestion = _suggest_with_openai(term, list(mapping.keys()))
+    if suggestion:
+        resp = input(f"Map '{term}' to '{suggestion}'? (Y/n): ").strip().lower()
+        if resp in ('', 'y', 'yes'):
+            add_alias(suggestion, term)
+            return suggestion
+    # manual selection
+    print(f"\nUnknown term: '{term}'.")
+    if mapping:
+        print("Available canonical terms:")
+        canonicals = list(mapping.keys())
+        for idx, c in enumerate(canonicals, start=1):
+            print(f"  {idx}) {c}")
+        print(f"  {len(canonicals)+1}) Create new canonical term")
+        choice = input(f"Select 1-{len(canonicals)+1}: ").strip()
+        if choice.isdigit():
+            idx = int(choice)
+            if 1 <= idx <= len(canonicals):
+                canonical = canonicals[idx-1]
+                add_alias(canonical, term)
+                return canonical
+    # create new canonical
+    canonical = input("Enter new canonical term: ").strip()
+    if canonical:
+        add_alias(canonical, term)
+        return canonical
+    return term


### PR DESCRIPTION
## Summary
- implement `term_mapper` for managing canonical terms and OpenAI suggestions
- normalize sector and industry entries in portfolio and group management
- provide default mappings in `Config/term_mapping.json`
- update requirements with `openai` dependency

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_683fd5fab9708327a8b2ea71a56a3ac6