### PR TITLE
Add environment config loader

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,10 @@
+# Ignore configuration files and secrets
+config/*
+!config/.gitkeep
+
+# Byte-compiled / cache files
+__pycache__/
+*.py[cod]
+
+# Virtual environments
+.venv/

--- a/README.md
+++ b/README.md
@@ -117,3 +117,10 @@ When these variables are present `portfolio_manager` and `group_analysis` will
 read from and write to the specified Directus collections. If Directus is not
 reachable the tools automatically fall back to the Excel files.
 
+### Configuration & Secrets
+
+Place any API keys (e.g. Directus, OpenBB, OpenAI) in `config/.env` and user
+preferences in `config/settings.json`. These files are ignored by Git and will
+not be committed. The application automatically loads variables from `.env` on
+startup using `python-dotenv`.
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,3 +14,4 @@ matplotlib
 yfinance==0.2.58
 openai==1.84.0
 requests==2.32.3
+python-dotenv

--- a/src/config_utils.py
+++ b/src/config_utils.py
@@ -1,0 +1,29 @@
+"""Utilities for loading environment variables and user settings."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Dict
+
+from dotenv import load_dotenv
+
+# Directory containing config files
+CONFIG_DIR = Path(__file__).resolve().parent.parent / "config"
+ENV_PATH = CONFIG_DIR / ".env"
+SETTINGS_PATH = CONFIG_DIR / "settings.json"
+
+# Load environment variables from .env if present
+if ENV_PATH.exists():
+    load_dotenv(dotenv_path=ENV_PATH)
+
+
+def load_settings() -> Dict[str, Any]:
+    """Return settings dictionary loaded from config/settings.json if it exists."""
+    if SETTINGS_PATH.exists():
+        try:
+            with open(SETTINGS_PATH, "r", encoding="utf-8") as f:
+                return json.load(f)
+        except Exception:
+            pass
+    return {}

--- a/src/directus_client.py
+++ b/src/directus_client.py
@@ -1,6 +1,10 @@
 import os
 import requests
 
+from config_utils import load_settings  # noqa: E402
+
+load_settings()  # ensure .env is read when this module is imported
+
 DIRECTUS_URL = os.getenv("DIRECTUS_URL")
 DIRECTUS_TOKEN = os.getenv("DIRECTUS_TOKEN")
 

--- a/src/group_analysis/group_analysis.py
+++ b/src/group_analysis/group_analysis.py
@@ -25,6 +25,10 @@ import os
 import sys
 from typing import Optional
 
+from config_utils import load_settings  # noqa: E402
+
+SETTINGS = load_settings()
+
 import pandas as pd
 import yfinance as yf
 import requests

--- a/src/main.py
+++ b/src/main.py
@@ -2,9 +2,14 @@
 
 import sys
 
+# Ensure environment variables from config/.env are loaded before other modules
+from config_utils import load_settings  # noqa: E402
+
 from portfolio_manager.portfolio_manager import main as run_portfolio_manager
 from group_analysis.group_analysis import main as run_group_analysis
 from generate_report import run_generate_report
+
+SETTINGS = load_settings()
 
 
 def exit_program():

--- a/src/portfolio_manager/portfolio_manager.py
+++ b/src/portfolio_manager/portfolio_manager.py
@@ -19,6 +19,10 @@ import os
 import sys
 from typing import Optional
 
+from config_utils import load_settings  # noqa: E402
+
+SETTINGS = load_settings()
+
 import pandas as pd
 import yfinance as yf
 import requests

--- a/src/term_mapper.py
+++ b/src/term_mapper.py
@@ -2,6 +2,10 @@ import json
 import os
 from typing import Dict, List, Optional
 
+from config_utils import load_settings  # noqa: E402
+
+load_settings()
+
 try:
     import openai
 except Exception:


### PR DESCRIPTION
## Summary
- ignore `config/` secrets folder
- document new config files in README
- add `python-dotenv` dependency
- load `.env` and optional `settings.json` via `config_utils`
- use config loader in main modules

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684019e4ab6c8327a29c88fd6738f3a6