### PR TITLE
Refactor: add analysis utilities

### DIFF
--- a/modules/analysis.py
+++ b/modules/analysis.py
@@ -1,0 +1,15 @@
+"""Simple portfolio and group analysis utilities."""
+from __future__ import annotations
+
+import pandas as pd
+
+
+def portfolio_summary(df: pd.DataFrame) -> pd.DataFrame:
+    """Return basic summary statistics for numeric columns."""
+    if df is None or df.empty:
+        return pd.DataFrame()
+    numeric_cols = [c for c in df.columns if pd.api.types.is_numeric_dtype(df[c])]
+    if not numeric_cols:
+        return pd.DataFrame()
+    summary = df[numeric_cols].describe().loc[["mean", "min", "max"]]
+    return summary

--- a/modules/data_compare.py
+++ b/modules/data_compare.py
@@ -2,7 +2,6 @@ import logging
 from typing import Dict, Tuple
 
 import pandas as pd
-from openbb import obb
 import yfinance as yf
 
 logger = logging.getLogger(__name__)
@@ -13,6 +12,7 @@ ESSENTIAL_COLS = ["longName", "sector", "industry", "marketCap", "website"]
 def fetch_profile_openbb(symbol: str) -> pd.DataFrame:
     """Fetch company profile via OpenBB. Returns empty DataFrame on error."""
     try:
+        from openbb import obb  # imported lazily to avoid heavy startup if unused
         obj = obb.equity.profile(symbol=symbol)
         df = obj.to_df()
         return df

--- a/modules/group_analysis/group_analysis.py
+++ b/modules/group_analysis/group_analysis.py
@@ -26,6 +26,7 @@ import sys
 from typing import Optional
 
 from modules.config_utils import load_settings  # noqa: E402
+from modules.analysis import portfolio_summary
 
 SETTINGS = load_settings()
 
@@ -347,6 +348,9 @@ def view_groups(groups: pd.DataFrame):
         print(f"Group: {grp}")
         sub = groups[groups["Group"] == grp]
         print(sub[["Ticker", "Name", "Sector", "Industry", "Current Price"]].to_string(index=False))
+        summary = portfolio_summary(sub)
+        if not summary.empty:
+            print(summary.to_string())
         print("")
 
 

--- a/modules/portfolio_manager/portfolio_manager.py
+++ b/modules/portfolio_manager/portfolio_manager.py
@@ -20,6 +20,7 @@ import sys
 from typing import Optional
 
 from modules.config_utils import load_settings  # noqa: E402
+from modules.analysis import portfolio_summary
 
 SETTINGS = load_settings()
 
@@ -269,6 +270,10 @@ def view_portfolio(portfolio: pd.DataFrame):
 
     print("\nCurrent Portfolio:")
     print(portfolio.to_string(index=False))
+    summary = portfolio_summary(portfolio)
+    if not summary.empty:
+        print("\nSummary (mean/min/max):")
+        print(summary.to_string())
     print("")
 
 


### PR DESCRIPTION
## Summary
- create `modules/analysis.py` with basic portfolio summary
- lazily import OpenBB in `data_compare` to speed up tests
- show summary info in portfolio and group views

## Testing
- `pytest -q tests/test_diff.py -vv`

------
https://chatgpt.com/codex/tasks/task_e_6840207b1a5883279e22cbea6f181fdb