### PR TITLE
Add simple Markdown note system

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,18 @@ When these variables are present `portfolio_manager` and `group_analysis` will
 read from and write to the specified Directus collections. If Directus is not
 reachable the tools automatically fall back to the Excel files.
 
+### Note Manager
+
+Fundalyze includes a basic Markdown note system. Launch it from the main menu
+or directly with:
+
+```bash
+python scripts/note_cli.py
+```
+
+Notes are stored in the `notes/` directory and support Obsidian style
+`[[wikilinks]]` for linking between files.
+
 ### Configuration & Secrets
 
 Place any API keys (e.g. Directus, OpenBB, OpenAI) in `config/.env` and user

--- a/modules/note_manager/__init__.py
+++ b/modules/note_manager/__init__.py
@@ -1,0 +1,19 @@
+from .note_manager import (
+    create_note,
+    get_note_path,
+    list_notes,
+    parse_links,
+    read_note,
+    run_note_manager,
+    slugify,
+)
+
+__all__ = [
+    "create_note",
+    "get_note_path",
+    "list_notes",
+    "parse_links",
+    "read_note",
+    "run_note_manager",
+    "slugify",
+]

--- a/modules/note_manager/note_manager.py
+++ b/modules/note_manager/note_manager.py
@@ -1,0 +1,101 @@
+import os
+import re
+from pathlib import Path
+from typing import List, Optional
+
+
+def get_notes_dir() -> Path:
+    """Return the notes directory, creating it if needed."""
+    notes_dir = Path(os.environ.get("NOTES_DIR", "notes"))
+    notes_dir.mkdir(parents=True, exist_ok=True)
+    return notes_dir
+
+
+def slugify(title: str) -> str:
+    """Convert a note title into a filesystem-friendly slug."""
+    slug = title.lower()
+    slug = re.sub(r"[^a-z0-9]+", "-", slug)
+    return slug.strip("-")
+
+
+def get_note_path(title: str) -> Path:
+    """Return the Path for a given note title."""
+    return get_notes_dir() / f"{slugify(title)}.md"
+
+
+def create_note(title: str, content: str = "") -> Path:
+    """Create a new note with the given title and content."""
+    path = get_note_path(title)
+    header = f"# {title}\n\n"
+    if not path.exists():
+        path.write_text(header + content)
+    return path
+
+
+def read_note(title: str) -> Optional[str]:
+    """Return the contents of a note, or None if it doesn't exist."""
+    path = get_note_path(title)
+    if path.is_file():
+        return path.read_text()
+    return None
+
+
+def list_notes() -> List[str]:
+    """Return a list of available note titles (slugs)."""
+    notes_dir = get_notes_dir()
+    return [p.stem for p in notes_dir.glob("*.md")]
+
+
+def parse_links(content: str) -> List[str]:
+    """Return a list of note titles referenced via [[wikilink]] syntax."""
+    return re.findall(r"\[\[([^\]]+)\]\]", content)
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Simple CLI interface
+
+
+def run_note_manager() -> None:
+    """Interactive menu for creating and viewing notes."""
+    while True:
+        print("\n=== Notes ===")
+        print("1) List notes")
+        print("2) View note")
+        print("3) Create note")
+        print("4) Exit")
+        choice = input("Enter 1-4: ").strip()
+
+        if choice == "1":
+            notes = list_notes()
+            if not notes:
+                print("No notes found.")
+            else:
+                for n in notes:
+                    print(f"- {n}")
+        elif choice == "2":
+            title = input("Note title: ").strip()
+            content = read_note(title)
+            if content is None:
+                print("Note not found.")
+            else:
+                print("\n" + content)
+                links = parse_links(content)
+                if links:
+                    print("\nLinks:")
+                    for link in links:
+                        print(f"- {link}")
+        elif choice == "3":
+            title = input("New note title: ").strip()
+            print("Enter note content. End with an empty line.")
+            lines: list[str] = []
+            while True:
+                line = input()
+                if line == "":
+                    break
+                lines.append(line)
+            create_note(title, "\n".join(lines))
+            print(f"Created note '{title}'.")
+        elif choice == "4":
+            break
+        else:
+            print("Invalid choice.\n")

--- a/scripts/main.py
+++ b/scripts/main.py
@@ -8,6 +8,7 @@ from modules.config_utils import load_settings  # noqa: E402
 from modules.portfolio_manager.portfolio_manager import main as run_portfolio_manager
 from modules.group_analysis.group_analysis import main as run_group_analysis
 from modules.generate_report import run_generate_report
+from modules.note_manager import run_note_manager
 
 SETTINGS = load_settings()
 
@@ -36,6 +37,7 @@ def main():
         ("Manage Portfolio",               run_portfolio_manager),
         ("Manage Groups",                  run_group_analysis),
         ("Generate Reports (with metadata, fallback & Excel)", run_generate_report),
+        ("Manage Notes",                  run_note_manager),
         ("Exit",                           exit_program),
     ]
 

--- a/scripts/note_cli.py
+++ b/scripts/note_cli.py
@@ -1,0 +1,4 @@
+from modules.note_manager import run_note_manager
+
+if __name__ == "__main__":
+    run_note_manager()

--- a/tests/test_note_manager.py
+++ b/tests/test_note_manager.py
@@ -1,0 +1,29 @@
+import os
+import tempfile
+
+import importlib
+
+from note_manager import note_manager
+
+
+def test_slugify():
+    assert note_manager.slugify("Hello World!") == "hello-world"
+
+
+def test_parse_links():
+    text = "See [[Note One]] and [[Note Two]] for details."
+    assert note_manager.parse_links(text) == ["Note One", "Note Two"]
+
+
+def test_create_and_read_note():
+    with tempfile.TemporaryDirectory() as tmp:
+        os.environ["NOTES_DIR"] = tmp
+        importlib.reload(note_manager)
+        note_manager.create_note("Test", "sample content")
+        path = note_manager.get_note_path("Test")
+        assert path.is_file()
+        content = note_manager.read_note("Test")
+        assert "sample content" in content
+        del os.environ["NOTES_DIR"]
+        importlib.reload(note_manager)
+


### PR DESCRIPTION
## Summary
- provide a note manager module with Obsidian-style `[[wikilinks]]`
- expose interactive CLI at `scripts/note_cli.py`
- integrate note manager into main menu
- document note functionality in README
- add tests for the new module

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6840255cc6288327bea122739025ad32