### PR TITLE
Add sector analytics feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,9 @@ Generate a multi-sheet Excel dashboard (with transposed tables) for quick analys
 ## Project Layout
 
 - `config/` – configuration files such as `finance_api.yaml`, `term_mapping.json`, `.env`, and `settings.json`.
-- `modules/` – reusable Python modules implementing the application's features.
+- `modules/` – reusable Python modules implementing the application's features. Includes
+  small analytics helpers such as `sector_counts()` for summarizing your portfolio by
+  sector.
 - `scripts/` – entry-point scripts like `main.py`.
 
 ### Comparing OpenBB and yfinance data

--- a/modules/analytics/__init__.py
+++ b/modules/analytics/__init__.py
@@ -13,3 +13,11 @@ def portfolio_summary(df: pd.DataFrame) -> pd.DataFrame:
         return pd.DataFrame()
     summary = df[numeric_cols].describe().loc[["mean", "min", "max"]]
     return summary
+
+
+def sector_counts(df: pd.DataFrame) -> pd.DataFrame:
+    """Return count of tickers per sector."""
+    if df is None or df.empty or "Sector" not in df.columns:
+        return pd.DataFrame()
+    counts = df["Sector"].fillna("Unknown").value_counts().rename_axis("Sector")
+    return counts.reset_index(name="Count")

--- a/modules/management/portfolio_manager/portfolio_manager.py
+++ b/modules/management/portfolio_manager/portfolio_manager.py
@@ -20,7 +20,7 @@ import sys
 from typing import Optional
 
 from modules.config_utils import load_settings  # noqa: E402
-from modules.analytics import portfolio_summary
+from modules.analytics import portfolio_summary, sector_counts
 
 SETTINGS = load_settings()
 
@@ -274,6 +274,11 @@ def view_portfolio(portfolio: pd.DataFrame):
     if not summary.empty:
         print("\nSummary (mean/min/max):")
         print(summary.to_string())
+    counts = sector_counts(portfolio)
+    if not counts.empty:
+        print("\nSectors:")
+        for _, row in counts.iterrows():
+            print(f"  {row['Sector']}: {row['Count']}")
     print("")
 
 

--- a/tests/test_analysis.py
+++ b/tests/test_analysis.py
@@ -1,5 +1,5 @@
 import pandas as pd
-from analytics import portfolio_summary
+from analytics import portfolio_summary, sector_counts
 
 
 def test_portfolio_summary_numeric_columns():
@@ -18,3 +18,17 @@ def test_portfolio_summary_numeric_columns():
 
 def test_portfolio_summary_empty():
     assert portfolio_summary(pd.DataFrame()).empty
+
+
+def test_sector_counts_basic():
+    df = pd.DataFrame({"Sector": ["Tech", "Health", "Tech", None]})
+    result = sector_counts(df)
+    assert len(result) == 3
+    assert result.iloc[0].tolist() == ["Tech", 2]
+    assert result.iloc[1].tolist() == ["Health", 1]
+    assert result.iloc[2].tolist() == ["Unknown", 1]
+
+
+def test_sector_counts_no_sector_column():
+    df = pd.DataFrame({"Ticker": ["A", "B"]})
+    assert sector_counts(df).empty


### PR DESCRIPTION
## Summary
- implement `sector_counts` helper for summarizing sectors
- display sector distribution in portfolio manager
- document analytics in README
- test new analytics helper

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68403668d50c832793d7b1bad43499f5