### PR TITLE
Add tests for config utils and fetching

### DIFF
--- a/tests/test_config_utils.py
+++ b/tests/test_config_utils.py
@@ -1,0 +1,18 @@
+import json
+import modules.config_utils as config_utils
+
+
+def test_load_settings_missing(tmp_path, monkeypatch):
+    fake_path = tmp_path / "settings.json"
+    monkeypatch.setattr(config_utils, "SETTINGS_PATH", fake_path)
+    result = config_utils.load_settings()
+    assert result == {}
+
+
+def test_load_settings_with_file(tmp_path, monkeypatch):
+    data = {"foo": 123, "bar": True}
+    fake_path = tmp_path / "settings.json"
+    fake_path.write_text(json.dumps(data))
+    monkeypatch.setattr(config_utils, "SETTINGS_PATH", fake_path)
+    result = config_utils.load_settings()
+    assert result == data

--- a/tests/test_fetching.py
+++ b/tests/test_fetching.py
@@ -1,0 +1,48 @@
+from unittest.mock import MagicMock, patch
+
+from modules.data.fetching import fetch_basic_stock_data
+
+
+def test_fetch_basic_stock_data_basic():
+    mock_info = {
+        "longName": "Acme Corp",
+        "sector": "Tech",
+        "industry": "Software",
+        "currentPrice": 100.0,
+        "marketCap": 2000000,
+        "trailingPE": 15.0,
+        "dividendYield": 0.01,
+    }
+
+    with patch("modules.data.fetching.yf.Ticker") as mock_ticker_cls, \
+         patch("modules.data.fetching.resolve_term", side_effect=lambda x: x):
+        mock_ticker = MagicMock()
+        mock_ticker.info = mock_info
+        mock_ticker_cls.return_value = mock_ticker
+
+        result = fetch_basic_stock_data("ACME")
+
+    expected = {
+        "Ticker": "ACME",
+        "Name": "Acme Corp",
+        "Sector": "Tech",
+        "Industry": "Software",
+        "Current Price": 100.0,
+        "Market Cap": 2000000,
+        "PE Ratio": 15.0,
+        "Dividend Yield": 0.01,
+    }
+    assert result == expected
+
+
+def test_fetch_basic_stock_data_invalid():
+    with patch("modules.data.fetching.yf.Ticker") as mock_ticker_cls, \
+         patch("modules.data.fetching.resolve_term", side_effect=lambda x: x):
+        mock_ticker = MagicMock()
+        mock_ticker.info = {}
+        mock_ticker_cls.return_value = mock_ticker
+
+        import pytest
+        with pytest.raises(ValueError):
+            fetch_basic_stock_data("BAD")
+


### PR DESCRIPTION
## Summary
- add tests for the settings loader
- add tests for fetching basic stock data

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6840420a1974832793c9a2235122c1cb