### PR TITLE
Improve data module

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Fundalyze is a lightweight Python application for fetching, analyzing and visualizing investment portfolio data. It automates:
 
-- **Data Acquisition** – fetches prices, company profiles and financial statements via OpenBB, yfinance and FMP.
+- **Data Acquisition** – fetches data via OpenBB and yfinance, automatically falling back to FMP when needed.
 - **Metadata Management** – verifies each ticker's completeness, re-fetches missing files and records source URLs.
 - **Dashboard Generation** – aggregates raw CSVs into a multi-sheet Excel workbook so metrics can be inspected over time.
 

--- a/modules/data/fetching.py
+++ b/modules/data/fetching.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import pandas as pd
+import requests
 import yfinance as yf
 
 from .term_mapper import resolve_term
@@ -19,12 +20,11 @@ BASIC_FIELDS = [
 ]
 
 
-def fetch_basic_stock_data(ticker: str) -> dict:
-    """Fetch key fundamental data for a ticker via yfinance."""
-    ticker_obj = yf.Ticker(ticker)
-    info = ticker_obj.info
-    if not info or "longName" not in info or info["longName"] is None:
-        raise ValueError("No valid data returned by yfinance.")
+FMP_PROFILE_URL = "https://financialmodelingprep.com/api/v3/profile/{symbol}"
+
+
+def _parse_yf_info(info: dict, ticker: str) -> dict:
+    """Return BASIC_FIELDS dict from yfinance info dict."""
     return {
         "Ticker": ticker.upper(),
         "Name": info.get("longName", ""),
@@ -35,3 +35,41 @@ def fetch_basic_stock_data(ticker: str) -> dict:
         "PE Ratio": info.get("trailingPE", pd.NA),
         "Dividend Yield": info.get("dividendYield", pd.NA),
     }
+
+
+def _fetch_from_fmp(ticker: str) -> dict:
+    """Return BASIC_FIELDS dict using FMP profile endpoint."""
+    url = FMP_PROFILE_URL.format(symbol=ticker)
+    resp = requests.get(url)
+    resp.raise_for_status()
+    data = resp.json()
+    if not data or not isinstance(data, list):
+        return {}
+    row = data[0]
+    return {
+        "Ticker": ticker.upper(),
+        "Name": row.get("companyName", ""),
+        "Sector": resolve_term(row.get("sector", "")),
+        "Industry": resolve_term(row.get("industry", "")),
+        "Current Price": row.get("price", pd.NA),
+        "Market Cap": row.get("mktCap", pd.NA),
+        "PE Ratio": row.get("pe", pd.NA),
+        "Dividend Yield": row.get("lastDiv", pd.NA),
+    }
+
+
+def fetch_basic_stock_data(ticker: str, *, fallback: bool = True) -> dict:
+    """Fetch key fundamental data for a ticker via yfinance with optional FMP fallback."""
+    ticker_obj = yf.Ticker(ticker)
+    try:
+        info = ticker_obj.get_info()
+    except Exception:
+        info = {}
+    if info and info.get("longName") is not None:
+        return _parse_yf_info(info, ticker)
+    if not fallback:
+        raise ValueError("No valid data returned by yfinance.")
+    fmp_data = _fetch_from_fmp(ticker)
+    if not fmp_data:
+        raise ValueError("No valid data returned by yfinance or FMP.")
+    return fmp_data

--- a/tests/test_fetching.py
+++ b/tests/test_fetching.py
@@ -17,7 +17,7 @@ def test_fetch_basic_stock_data_basic():
     with patch("modules.data.fetching.yf.Ticker") as mock_ticker_cls, \
          patch("modules.data.fetching.resolve_term", side_effect=lambda x: x):
         mock_ticker = MagicMock()
-        mock_ticker.info = mock_info
+        mock_ticker.get_info.return_value = mock_info
         mock_ticker_cls.return_value = mock_ticker
 
         result = fetch_basic_stock_data("ACME")
@@ -35,14 +35,53 @@ def test_fetch_basic_stock_data_basic():
     assert result == expected
 
 
-def test_fetch_basic_stock_data_invalid():
+def test_fetch_basic_stock_data_invalid_no_fallback():
     with patch("modules.data.fetching.yf.Ticker") as mock_ticker_cls, \
          patch("modules.data.fetching.resolve_term", side_effect=lambda x: x):
         mock_ticker = MagicMock()
-        mock_ticker.info = {}
+        mock_ticker.get_info.return_value = {}
         mock_ticker_cls.return_value = mock_ticker
 
         import pytest
         with pytest.raises(ValueError):
-            fetch_basic_stock_data("BAD")
+            fetch_basic_stock_data("BAD", fallback=False)
+
+
+def test_fetch_basic_stock_data_fmp_fallback():
+    mock_fmp_data = [{
+        "symbol": "ACME",
+        "companyName": "Acme Corp",
+        "sector": "Tech",
+        "industry": "Software",
+        "price": 50.0,
+        "mktCap": 1000000,
+        "pe": 12.0,
+        "lastDiv": 0.02,
+    }]
+
+    with patch("modules.data.fetching.yf.Ticker") as mock_ticker_cls, \
+         patch("modules.data.fetching.requests.get") as mock_get, \
+         patch("modules.data.fetching.resolve_term", side_effect=lambda x: x):
+        mock_ticker = MagicMock()
+        mock_ticker.get_info.return_value = {}
+        mock_ticker_cls.return_value = mock_ticker
+
+        mock_resp = MagicMock()
+        mock_resp.json.return_value = mock_fmp_data
+        mock_resp.raise_for_status.return_value = None
+        mock_get.return_value = mock_resp
+
+        result = fetch_basic_stock_data("ACME")
+
+    expected = {
+        "Ticker": "ACME",
+        "Name": "Acme Corp",
+        "Sector": "Tech",
+        "Industry": "Software",
+        "Current Price": 50.0,
+        "Market Cap": 1000000,
+        "PE Ratio": 12.0,
+        "Dividend Yield": 0.02,
+    }
+    assert result == expected
 


### PR DESCRIPTION
## Summary
- add FMP fallback to `fetch_basic_stock_data`
- document fallback behavior in README
- test FMP fallback and option to disable it

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6840468057808327874fe7036ea4a03a