### PR TITLE
Add tests for Directus client and portfolio manager

### DIFF
--- a/tests/test_directus_client.py
+++ b/tests/test_directus_client.py
@@ -1,0 +1,52 @@
+from unittest.mock import MagicMock
+
+import modules.data.directus_client as dc
+
+
+def test_headers_with_token(monkeypatch):
+    monkeypatch.setattr(dc, "DIRECTUS_TOKEN", "abc")
+    assert dc._headers() == {"Authorization": "Bearer abc"}
+
+
+def test_headers_no_token(monkeypatch):
+    monkeypatch.setattr(dc, "DIRECTUS_TOKEN", None)
+    assert dc._headers() == {}
+
+
+def test_list_fields(monkeypatch):
+    monkeypatch.setattr(dc, "DIRECTUS_URL", "http://api")
+    resp = MagicMock()
+    resp.json.return_value = {"data": [{"field": "a"}, {"field": "b"}]}
+    resp.raise_for_status.return_value = None
+    monkeypatch.setattr(dc.requests, "get", lambda url, headers: resp)
+    fields = dc.list_fields("col")
+    assert fields == ["a", "b"]
+
+
+def test_fetch_items(monkeypatch):
+    monkeypatch.setattr(dc, "DIRECTUS_URL", "http://api")
+    resp = MagicMock()
+    resp.json.return_value = {"data": [{"x": 1}]}
+    resp.raise_for_status.return_value = None
+    monkeypatch.setattr(dc.requests, "get", lambda url, headers: resp)
+    items = dc.fetch_items("col")
+    assert items == [{"x": 1}]
+
+
+def test_insert_items(monkeypatch):
+    monkeypatch.setattr(dc, "DIRECTUS_URL", "http://api")
+    resp = MagicMock()
+    resp.json.return_value = {"data": [1]}
+    resp.raise_for_status.return_value = None
+    monkeypatch.setattr(dc.requests, "post", lambda url, json, headers: resp)
+    res = dc.insert_items("col", [1])
+    assert res == [1]
+
+def test_requires_url(monkeypatch):
+    monkeypatch.setattr(dc, "DIRECTUS_URL", None)
+    try:
+        dc.list_fields("col")
+    except RuntimeError:
+        assert True
+    else:
+        assert False

--- a/tests/test_portfolio_manager.py
+++ b/tests/test_portfolio_manager.py
@@ -1,0 +1,32 @@
+import pandas as pd
+import modules.management.portfolio_manager.portfolio_manager as pm
+
+
+def test_load_portfolio_local(monkeypatch):
+    monkeypatch.setattr(pm, "USE_DIRECTUS", False)
+    monkeypatch.setattr(pm.os.path, "isfile", lambda f: True)
+    df = pd.DataFrame({"Ticker": ["A"], "Name": ["Acme"]})
+    monkeypatch.setattr(pm.pd, "read_excel", lambda f, engine=None: df)
+    result = pm.load_portfolio("dummy")
+    assert "Ticker" in result.columns
+    assert result.iloc[0]["Name"] == "Acme"
+
+
+def test_load_portfolio_directus(monkeypatch):
+    monkeypatch.setattr(pm, "USE_DIRECTUS", True)
+    monkeypatch.setattr(pm, "fetch_items", lambda c: [{"Ticker": "A", "Name": "Acme"}])
+    result = pm.load_portfolio("dummy")
+    assert list(result.columns)[0] == "Ticker"
+    assert result.iloc[0]["Name"] == "Acme"
+
+
+def test_save_portfolio_directus(monkeypatch):
+    monkeypatch.setattr(pm, "USE_DIRECTUS", True)
+    monkeypatch.setattr(pm, "list_fields", lambda c: ["Ticker", "Name"])
+    records_holder = {}
+    def fake_insert(collection, records):
+        records_holder['rec'] = records
+    monkeypatch.setattr(pm, "insert_items", fake_insert)
+    df = pd.DataFrame({"Ticker": ["A"], "Name": ["Acme"], "Extra": [1]})
+    pm.save_portfolio(df, "dummy")
+    assert records_holder['rec'] == [{"Ticker": "A", "Name": "Acme"}]


### PR DESCRIPTION
## Summary
- add tests covering Directus client helper
- add tests for portfolio manager load/save logic

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68404d5034f883278e6d3f22dd8353a4