### PR TITLE
Add documentation for modules and configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,3 +122,8 @@ python scripts/performance_profile.py
 ```
 
 Results are summarized in [docs/performance_benchmarks.md](docs/performance_benchmarks.md).
+
+## Further Documentation
+
+- [Codebase Overview](docs/overview.md) – quick tour of modules and entry points.
+- [Configuration Guide](docs/configuration.md) – setting up `.env` and `settings.json`.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,0 +1,41 @@
+# Configuration & Secrets
+
+Fundalyze reads configuration from the `config/` directory at startup. Two optional files are supported:
+
+1. **`.env`** – environment variables such as API tokens.
+2. **`settings.json`** – user preferences in JSON format.
+
+Both files are ignored by Git so you can safely store credentials locally.
+
+## Creating `config/.env`
+Example contents:
+```env
+# API keys
+OPENBB_TOKEN=your-openbb-key
+DIRECTUS_URL=https://your-directus.example.com
+DIRECTUS_TOKEN=secret-token
+
+# Optional collection names
+DIRECTUS_PORTFOLIO_COLLECTION=portfolio
+DIRECTUS_GROUPS_COLLECTION=groups
+```
+`modules.config_utils` automatically loads this file using [python-dotenv](https://github.com/theskumar/python-dotenv) whenever `load_settings()` is called.
+
+## Creating `config/settings.json`
+This file stores additional preferences that are not secrets. A minimal example:
+```json
+{
+  "currency": "USD",
+  "timezone": "UTC"
+}
+```
+`load_settings()` returns the parsed dictionary so other modules can access these values.
+
+## Initial Setup
+1. Clone the repository and run one of the `bootstrap_env` scripts to create a virtual environment and install dependencies.
+2. Populate `config/.env` and optionally `config/settings.json` as shown above.
+3. Launch the CLI with:
+   ```bash
+   python scripts/main.py
+   ```
+The application will pick up your configuration automatically on startup.

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -1,0 +1,38 @@
+# Codebase Overview
+
+This document summarizes the major modules and entry points within **Fundalyze**. Use it as a quick reference when exploring or extending the project.
+
+## Module Packages
+
+### `modules.generate_report`
+Utilities for building ticker reports and Excel dashboards.
+- `report_generator.py` – fetches profile data, price history and financial statements via OpenBB, saving each dataset under `output/<TICKER>/`.
+- `metadata_checker.py` – scans downloaded metadata for errors and attempts to re‑fetch missing information.
+- `fallback_data.py` – performs a full yfinance fallback when primary sources fail.
+- `excel_dashboard.py` – combines individual CSV files into a multi‑sheet Excel workbook.
+
+The package exposes the convenience function `run_generate_report()` which orchestrates all of the above steps.
+
+### `modules.management`
+Tools for maintaining local data files:
+- `portfolio_manager` – CLI for creating and editing `portfolio.xlsx`.
+- `group_analysis` – manage related tickers in `groups.xlsx`.
+- `note_manager` – simple Markdown note system supporting `[[wikilinks]]`.
+
+### `modules.data`
+Lower-level helpers used across the app:
+- `fetching.py` – small wrappers around yfinance and HTTP calls.
+- `directus_client.py` – optional Directus integration for remote storage.
+- `term_mapper.py` – maps common financial terms to API field names and stores the mapping in `config/term_mapping.json`.
+
+### `modules.config_utils`
+Loads environment variables from `config/.env` and user settings from `config/settings.json`. Call `load_settings()` once during startup so other modules can access configuration values via `os.getenv()` or the returned dictionary.
+
+## Script Entry Points
+
+The `scripts/` directory contains small wrappers that import the modules above:
+- `main.py` – interactive menu and command-line interface. From here you can launch portfolio management, group tools, report generation and the note manager.
+- `note_cli.py` – legacy entry point equivalent to running `main.py notes`.
+- `performance_profile.py` – micro-benchmark utility.
+
+Running `python scripts/main.py` without arguments opens the interactive menu; see the README for command examples.


### PR DESCRIPTION
## Summary
- document modules, scripts and entry points in `docs/overview.md`
- explain configuration & secrets setup in `docs/configuration.md`
- link new docs from the README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684058e626608327aa52c4559376aef6