### PR TITLE
Improve CLI user experience

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ With modular scripts for report generation, fallback data enrichment and portfol
 
 ## Usage
 
-After bootstrapping run `python scripts/main.py` to open the interactive menu. From here you can:
+After bootstrapping run `python scripts/main.py` to open the interactive menu. The CLI now uses **tabulate** for nicely formatted tables. From here you can:
 
 - Manage Portfolio
 - Manage Groups

--- a/modules/interface.py
+++ b/modules/interface.py
@@ -1,0 +1,12 @@
+from __future__ import annotations
+
+import pandas as pd
+from tabulate import tabulate
+
+
+def print_table(df: pd.DataFrame, *, showindex: bool = False) -> None:
+    """Pretty-print a DataFrame using :mod:`tabulate`."""
+    if df is None or df.empty:
+        print("(no data)")
+        return
+    print(tabulate(df, headers="keys", tablefmt="fancy_grid", showindex=showindex))

--- a/modules/management/group_analysis/group_analysis.py
+++ b/modules/management/group_analysis/group_analysis.py
@@ -27,6 +27,7 @@ from typing import Optional
 
 from modules.config_utils import load_settings  # noqa: E402
 from modules.analytics import portfolio_summary
+from modules.interface import print_table
 
 SETTINGS = load_settings()
 
@@ -346,11 +347,11 @@ def view_groups(groups: pd.DataFrame):
     print("\n=== All Groups & Members ===\n")
     for grp in groups["Group"].dropna().unique():
         print(f"Group: {grp}")
-        sub = groups[groups["Group"] == grp]
-        print(sub[["Ticker", "Name", "Sector", "Industry", "Current Price"]].to_string(index=False))
+        sub = groups[groups["Group"] == grp][["Ticker", "Name", "Sector", "Industry", "Current Price"]]
+        print_table(sub)
         summary = portfolio_summary(sub)
         if not summary.empty:
-            print(summary.to_string())
+            print_table(summary, showindex=True)
         print("")
 
 

--- a/modules/management/portfolio_manager/portfolio_manager.py
+++ b/modules/management/portfolio_manager/portfolio_manager.py
@@ -20,6 +20,7 @@ import sys
 from typing import Optional
 
 from modules.analytics import portfolio_summary, sector_counts
+from modules.interface import print_table
 
 import pandas as pd
 import requests
@@ -266,16 +267,15 @@ def view_portfolio(portfolio: pd.DataFrame):
         return
 
     print("\nCurrent Portfolio:")
-    print(portfolio.to_string(index=False))
+    print_table(portfolio)
     summary = portfolio_summary(portfolio)
     if not summary.empty:
         print("\nSummary (mean/min/max):")
-        print(summary.to_string())
+        print_table(summary, showindex=True)
     counts = sector_counts(portfolio)
     if not counts.empty:
         print("\nSectors:")
-        for _, row in counts.iterrows():
-            print(f"  {row['Sector']}: {row['Count']}")
+        print_table(counts)
     print("")
 
 


### PR DESCRIPTION
## Summary
- add `print_table()` helper using `tabulate`
- print portfolio and group tables with `tabulate`
- mention nicer table output in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68405c2a42e4832782b0bad0db7fe31d