### PR TITLE
Add new unit tests

### DIFF
--- a/tests/test_excel_dashboard_extra.py
+++ b/tests/test_excel_dashboard_extra.py
@@ -1,0 +1,16 @@
+import pytest
+from pathlib import Path
+
+from modules.generate_report.excel_dashboard import create_dashboard, show_dashboard_in_excel
+
+
+def test_create_dashboard_missing_folder(tmp_path):
+    missing = tmp_path / "nope"
+    with pytest.raises(FileNotFoundError):
+        create_dashboard(output_root=str(missing))
+
+
+def test_show_dashboard_in_excel_missing_file(tmp_path):
+    path = tmp_path / "dash.xlsx"
+    with pytest.raises(FileNotFoundError):
+        show_dashboard_in_excel(path)

--- a/tests/test_interface_extra.py
+++ b/tests/test_interface_extra.py
@@ -1,0 +1,15 @@
+import pandas as pd
+from modules.interface import print_table
+
+
+def test_print_table_empty(capsys):
+    print_table(pd.DataFrame())
+    captured = capsys.readouterr().out.strip()
+    assert captured == "(no data)"
+
+
+def test_print_table_non_empty(capsys):
+    df = pd.DataFrame({"A": [1]})
+    print_table(df)
+    out = capsys.readouterr().out
+    assert "A" in out and "1" in out

--- a/tests/test_metadata_checker.py
+++ b/tests/test_metadata_checker.py
@@ -1,0 +1,62 @@
+import pandas as pd
+from unittest.mock import MagicMock
+import pytest
+
+import modules.generate_report.metadata_checker as mc
+
+
+def test_iso_timestamp_utc_format():
+    ts = mc.iso_timestamp_utc()
+    assert "T" in ts and ts.endswith("Z")
+
+
+def test_fetch_profile_from_yf_basic(monkeypatch):
+    info = {
+        "longName": "Acme Corp",
+        "sector": "Tech",
+        "industry": "Software",
+        "marketCap": 100,
+        "website": "example.com",
+        "currentPrice": 10,
+    }
+
+    class FakeTicker:
+        def __init__(self, info):
+            self.info = info
+
+    monkeypatch.setattr(mc.yf, "Ticker", lambda s: FakeTicker(info))
+    df = mc.fetch_profile_from_yf("AAA")
+    assert df.iloc[0]["sector"] == "Tech"
+    assert df.iloc[0]["symbol"] == "AAA"
+
+
+def test_fetch_profile_from_yf_fmp_fallback(monkeypatch):
+    class FakeTicker:
+        info = {}
+
+    monkeypatch.setattr(mc.yf, "Ticker", lambda s: FakeTicker())
+    resp = MagicMock()
+    resp.json.return_value = [{
+        "symbol": "AAA",
+        "companyName": "Acme Corp",
+        "sector": "Tech",
+        "industry": "Software",
+        "mktCap": 100,
+        "website": "example.com",
+    }]
+    resp.raise_for_status.return_value = None
+    monkeypatch.setattr(mc.requests, "get", lambda url: resp)
+
+    df = mc.fetch_profile_from_yf("AAA")
+    assert df.iloc[0]["sector"] == "Tech"
+    assert df.iloc[0]["website"] == "example.com"
+
+
+def test_fetch_fmp_statement(monkeypatch):
+    resp = MagicMock()
+    resp.json.return_value = [{"date": "2023", "Revenue": 5}]
+    resp.raise_for_status.return_value = None
+    monkeypatch.setattr(mc.requests, "get", lambda url: resp)
+    df = mc.fetch_fmp_statement("AAA", "income-statement", "annual")
+    assert df.index.name == "date"
+    assert df.loc["2023", "Revenue"] == 5


### PR DESCRIPTION
## Summary
- cover interface.print_table output
- check create_dashboard and show_dashboard_in_excel error handling
- verify metadata utility helpers

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684064db7a608327aa67d7b77a918b80