### PR TITLE
Fix output path bug and add settings wizard

### DIFF
--- a/modules/generate_report/fallback_data.py
+++ b/modules/generate_report/fallback_data.py
@@ -41,7 +41,7 @@ def yf_full_fetch(symbol: str):
     print(f"\n=== YF Fallback: Processing {symbol} ===")
 
     # Ensure output/<symbol>/ exists
-    project_root = Path(__file__).parent.parent
+    project_root = Path(__file__).resolve().parents[2]
     output_dir = project_root / "output" / symbol
     os.makedirs(output_dir, exist_ok=True)
 
@@ -408,7 +408,7 @@ def enrich_ticker_folder(ticker_dir: Path):
 
 def run_fallback_data(tickers=None):
     """Run fallback enrichment for all or selected tickers."""
-    project_root = Path(__file__).parent.parent
+    project_root = Path(__file__).resolve().parents[2]
     output_root = project_root / "output"
 
     if not output_root.exists() or not output_root.is_dir():

--- a/modules/generate_report/metadata_checker.py
+++ b/modules/generate_report/metadata_checker.py
@@ -271,7 +271,7 @@ def enrich_ticker_folder(ticker_dir: Path):
 
 def run_for_tickers(tickers, output_root="output"):
     """Run metadata enrichment only for the specified ticker list."""
-    project_root = Path(__file__).parent.parent.parent
+    project_root = Path(__file__).resolve().parents[2]
     out_root = project_root / output_root
 
     if not out_root.exists() or not out_root.is_dir():
@@ -294,7 +294,7 @@ def run_for_tickers(tickers, output_root="output"):
 
 
 def main():
-    project_root = Path(__file__).parent.parent.parent
+    project_root = Path(__file__).resolve().parents[2]
     output_root = project_root / "output"
 
     if not output_root.exists() or not output_root.is_dir():

--- a/modules/generate_report/yf_fallback.py
+++ b/modules/generate_report/yf_fallback.py
@@ -16,7 +16,7 @@ def fetch_and_display(symbol: str):
     print(f"\n=== YF Fallback: Processing {symbol} ===")
 
     # Make sure the CSVs go into output/<symbol>/ instead of src/output/
-    project_root = Path(__file__).parent.parent
+    project_root = Path(__file__).resolve().parents[2]
     output_dir = project_root / "output" / symbol
     os.makedirs(output_dir, exist_ok=True)
 

--- a/modules/management/settings_manager/wizards/openai_key.py
+++ b/modules/management/settings_manager/wizards/openai_key.py
@@ -1,0 +1,27 @@
+"""Wizard to configure and validate the OpenAI API key."""
+
+import openai
+
+from modules.config_utils import load_env, save_env
+
+LABEL = "OpenAI API Key"
+
+
+def run_wizard() -> None:
+    print("\n=== OpenAI API Key Setup ===")
+    key = input("Enter OpenAI API Key: ").strip()
+    if not key:
+        print("No key provided.\n")
+        return
+
+    openai.api_key = key
+    try:
+        openai.models.list()
+    except Exception as e:
+        print(f"Validation failed: {e}\n")
+        return
+
+    env = load_env()
+    env["OPENAI_API_KEY"] = key
+    save_env(env)
+    print("API key saved to config/.env.\n")


### PR DESCRIPTION
## Summary
- correct repo root paths used by fallback and metadata scripts
- add modular settings manager with wizard discovery
- implement OpenAI API key wizard for example

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6840753f24bc83278a26d8c319aeb272