### PR TITLE
Add ticker refresh and selective dashboard

### DIFF
--- a/modules/generate_report/excel_dashboard.py
+++ b/modules/generate_report/excel_dashboard.py
@@ -90,7 +90,10 @@ def _safe_concat_normal(ticker_dfs: dict[str, pd.DataFrame]) -> pd.DataFrame:
     return pd.concat(frames, axis=0, ignore_index=True, sort=True)
 
 
-def create_dashboard(output_root: str = "output") -> Path:
+from typing import Iterable, Optional
+
+
+def create_dashboard(output_root: str = "output", *, tickers: Optional[Iterable[str]] = None) -> Path:
     """
     1) Find subfolders under output_root (one per ticker).
     2) Read these CSVs if present:
@@ -127,7 +130,15 @@ def create_dashboard(output_root: str = "output") -> Path:
     if not root.exists() or not root.is_dir():
         raise FileNotFoundError(f"Output folder '{output_root}' not found.")
 
-    ticker_dirs = sorted([p for p in root.iterdir() if p.is_dir()])
+    if tickers is None:
+        ticker_dirs = sorted([p for p in root.iterdir() if p.is_dir()])
+    else:
+        ticker_dirs = []
+        for tk in tickers:
+            td = root / tk
+            if td.is_dir():
+                ticker_dirs.append(td)
+
 
     profiles = {}
     prices = {}
@@ -418,11 +429,11 @@ def show_dashboard_in_excel(dashboard_path: Path):
         subprocess.call(["xdg-open", str(dashboard_path)])
 
 
-def create_and_open_dashboard(output_root: str = "output"):
+def create_and_open_dashboard(output_root: str = "output", *, tickers: Optional[Iterable[str]] = None):
     """
     Create an Excel dashboard (with named Tables) and open it automatically.
     """
-    dash_path = create_dashboard(output_root=output_root)
+    dash_path = create_dashboard(output_root=output_root, tickers=tickers)
     print(f"\n✅ Excel dashboard created at:\n   {dash_path}\n")
     print("Opening it now…\n")
     show_dashboard_in_excel(dash_path)

--- a/modules/management/portfolio_manager/portfolio_manager.py
+++ b/modules/management/portfolio_manager/portfolio_manager.py
@@ -258,6 +258,25 @@ def remove_ticker(portfolio: pd.DataFrame) -> pd.DataFrame:
     return portfolio
 
 
+def update_tickers(portfolio: pd.DataFrame) -> pd.DataFrame:
+    """Refresh data for each ticker via yfinance."""
+    if portfolio.empty:
+        print("Portfolio is empty.\n")
+        return portfolio
+
+    for idx, row in portfolio.iterrows():
+        tk = row["Ticker"]
+        try:
+            data = fetch_from_yfinance(tk)
+            for col in COLUMNS[1:]:
+                portfolio.at[idx, col] = data.get(col, portfolio.at[idx, col])
+            print(f"  ✓ Updated {tk}")
+        except Exception as e:
+            print(f"  × Could not update {tk}: {e}")
+
+    return portfolio
+
+
 def view_portfolio(portfolio: pd.DataFrame):
     """
     Display the current portfolio in a tabular format.
@@ -287,9 +306,10 @@ def main():
         print("Choose an action:")
         print("  1) View portfolio")
         print("  2) Add ticker(s)")
-        print("  3) Remove ticker")
-        print("  4) Exit")
-        choice = input("Enter 1/2/3/4: ").strip()
+        print("  3) Update ticker data")
+        print("  4) Remove ticker")
+        print("  5) Exit")
+        choice = input("Enter 1/2/3/4/5: ").strip()
 
         if choice == "1":
             view_portfolio(portfolio)
@@ -299,15 +319,19 @@ def main():
             save_portfolio(portfolio, PORTFOLIO_FILE)
 
         elif choice == "3":
-            portfolio = remove_ticker(portfolio)
+            portfolio = update_tickers(portfolio)
             save_portfolio(portfolio, PORTFOLIO_FILE)
 
         elif choice == "4":
+            portfolio = remove_ticker(portfolio)
+            save_portfolio(portfolio, PORTFOLIO_FILE)
+
+        elif choice == "5":
             print("Exiting Portfolio Manager.")
             break
 
         else:
-            print("Invalid choice. Please select 1, 2, 3, or 4.\n")
+            print("Invalid choice. Please select 1-5.\n")
 
 
 if __name__ == "__main__":

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -98,7 +98,7 @@ def test_portfolio_manager_cli_end_to_end(tmp_path, monkeypatch):
         "2",       # choose Add ticker
         "AAA",     # ticker list
         "y",       # accept info
-        "4",       # exit
+        "5",       # exit
     ])
     monkeypatch.setattr("builtins.input", lambda *_args: next(inputs))
 


### PR DESCRIPTION
## Summary
- refresh portfolio tickers via new `update_tickers` menu option
- allow selecting tickers manually, from portfolio or group when generating reports
- restrict Excel dashboard generation to selected tickers
- update tests for new menu

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68407d220b3c8327a80d008d3c22b744