### PR TITLE
Add Directus wizard and expand client

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,13 @@ export DIRECTUS_GROUPS_COLLECTION="groups"
 ```
 When these variables are present the tools will use Directus and automatically fall back to Excel if it is not reachable.
 
+You can manage collections interactively using the **Directus Wizard**:
+
+```bash
+python scripts/main.py directus
+```
+This helper lists collections, shows fields and allows you to create new fields or insert items from the command line.
+
 ### Note Manager
 
 A simple Markdown note system lives in `notes/`. Launch it with either the

--- a/modules/data/directus_client.py
+++ b/modules/data/directus_client.py
@@ -1,5 +1,6 @@
 import os
 import requests
+from typing import Any, Dict
 
 from modules.config_utils import load_settings  # noqa: E402
 
@@ -15,31 +16,44 @@ def _headers():
     return {}
 
 
-def list_fields(collection: str):
-    """Return list of field names for the given Directus collection."""
+def directus_request(method: str, path: str, **kwargs) -> Dict[str, Any]:
+    """Helper to send an authenticated request to the Directus API."""
     if not DIRECTUS_URL:
         raise RuntimeError("DIRECTUS_URL not configured")
-    resp = requests.get(f"{DIRECTUS_URL}/fields/{collection}", headers=_headers())
+    url = f"{DIRECTUS_URL.rstrip('/')}/{path.lstrip('/')}"
+    resp = requests.request(method, url, headers=_headers(), **kwargs)
     resp.raise_for_status()
-    data = resp.json().get("data", [])
+    return resp.json()
+
+def list_collections() -> list[str]:
+    """Return available collection names."""
+    data = directus_request("GET", "collections").get("data", [])
+    return [c.get("collection") for c in data]
+
+
+def list_fields(collection: str) -> list[str]:
+    """Return list of field names for the given Directus collection."""
+    data = directus_request("GET", f"fields/{collection}").get("data", [])
     return [f.get("field") for f in data]
 
 
 def fetch_items(collection: str):
     """Fetch all items from a Directus collection."""
-    if not DIRECTUS_URL:
-        raise RuntimeError("DIRECTUS_URL not configured")
-    resp = requests.get(f"{DIRECTUS_URL}/items/{collection}", headers=_headers())
-    resp.raise_for_status()
-    return resp.json().get("data", [])
+    data = directus_request("GET", f"items/{collection}").get("data", [])
+    return data
 
 
 def insert_items(collection: str, items):
     """Insert one or more items into a Directus collection."""
-    if not DIRECTUS_URL:
-        raise RuntimeError("DIRECTUS_URL not configured")
     payload = {"data": items}
-    resp = requests.post(f"{DIRECTUS_URL}/items/{collection}", json=payload, headers=_headers())
-    resp.raise_for_status()
-    return resp.json().get("data")
+    data = directus_request("POST", f"items/{collection}", json=payload).get("data")
+    return data
+
+
+def create_field(collection: str, field: str, field_type: str = "string", **kwargs):
+    """Create a new field in the given collection."""
+    payload = {"field": field, "type": field_type}
+    payload.update(kwargs)
+    data = directus_request("POST", f"fields/{collection}", json=payload).get("data")
+    return data
 

--- a/modules/management/directus_tools/__init__.py
+++ b/modules/management/directus_tools/__init__.py
@@ -1,0 +1,1 @@
+from .directus_wizard import run_directus_wizard

--- a/modules/management/directus_tools/directus_wizard.py
+++ b/modules/management/directus_tools/directus_wizard.py
@@ -1,0 +1,60 @@
+import json
+
+from modules.data import directus_client as dc
+
+
+def run_directus_wizard() -> None:
+    """Interactive wizard for common Directus API operations."""
+    if not dc.DIRECTUS_URL:
+        print("DIRECTUS_URL not configured in config/.env\n")
+        return
+
+    while True:
+        print("\n=== Directus API Wizard ===")
+        print("1) List collections")
+        print("2) View fields of a collection")
+        print("3) Add field to a collection")
+        print("4) Fetch items from a collection")
+        print("5) Insert item into a collection")
+        print("6) Exit")
+        choice = input("Select 1-6: ").strip()
+
+        if choice == "1":
+            cols = dc.list_collections()
+            print("Available collections:")
+            for c in cols:
+                print(f"  - {c}")
+        elif choice == "2":
+            col = input("Collection name: ").strip()
+            if col:
+                fields = dc.list_fields(col)
+                print(f"Fields for '{col}':")
+                for f in fields:
+                    print(f"  - {f}")
+        elif choice == "3":
+            col = input("Collection name: ").strip()
+            field = input("New field name: ").strip()
+            ftype = input("Field type [string]: ").strip() or "string"
+            if col and field:
+                dc.create_field(col, field, ftype)
+                print("Field created.\n")
+        elif choice == "4":
+            col = input("Collection name: ").strip()
+            if col:
+                items = dc.fetch_items(col)
+                print(json.dumps(items, indent=2))
+        elif choice == "5":
+            col = input("Collection name: ").strip()
+            raw = input("JSON for single item: ").strip()
+            if col and raw:
+                try:
+                    data = json.loads(raw)
+                except Exception as exc:
+                    print(f"Invalid JSON: {exc}\n")
+                else:
+                    dc.insert_items(col, [data])
+                    print("Item inserted.\n")
+        elif choice == "6":
+            break
+        else:
+            print("Invalid choice.\n")

--- a/scripts/main.py
+++ b/scripts/main.py
@@ -26,6 +26,9 @@ from modules.management.note_manager import run_note_manager
 from modules.management.settings_manager.settings_manager import (
     run_settings_manager,
 )
+from modules.management.directus_tools.directus_wizard import (
+    run_directus_wizard,
+)
 
 SETTINGS = load_settings()
 
@@ -48,7 +51,10 @@ def interactive_menu():
       1) Manage Portfolio       → portfolio_manager/portfolio_manager.py
       2) Manage Groups          → group_analysis/group_analysis.py
       3) Generate Reports       → generate_report/run_generate_report()
-      4) Exit
+      4) Manage Notes           → note_manager/run_note_manager()
+      5) Manage Settings        → settings_manager/settings_manager.py
+      6) Directus Wizard        → directus_tools/directus_wizard.py
+      7) Exit
     """
     ACTIONS = [
         ("Manage Portfolio",               run_portfolio_manager),
@@ -56,6 +62,7 @@ def interactive_menu():
         ("Generate Reports (with metadata, fallback & Excel)", run_generate_report),
         ("Manage Notes",                  run_note_manager),
         ("Manage Settings",               run_settings_manager),
+        ("Directus Wizard",               run_directus_wizard),
         ("Exit",                           exit_program),
     ]
 
@@ -88,6 +95,7 @@ def parse_args() -> argparse.Namespace:
     sub.add_parser("metadata", help="Run metadata checker")
     sub.add_parser("fallback", help="Run fallback data fetch")
     sub.add_parser("dashboard", help="Create Excel dashboard")
+    sub.add_parser("directus", help="Launch Directus wizard")
     sub.add_parser("menu", help="Interactive menu (default)")
     return parser.parse_args()
 
@@ -111,6 +119,8 @@ def main() -> None:
         run_fallback_data()
     elif cmd == "dashboard":
         create_and_open_dashboard()
+    elif cmd == "directus":
+        run_directus_wizard()
     else:
         interactive_menu()
 

--- a/tests/test_directus_client.py
+++ b/tests/test_directus_client.py
@@ -15,32 +15,62 @@ def test_headers_no_token(monkeypatch):
 
 def test_list_fields(monkeypatch):
     monkeypatch.setattr(dc, "DIRECTUS_URL", "http://api")
-    resp = MagicMock()
-    resp.json.return_value = {"data": [{"field": "a"}, {"field": "b"}]}
-    resp.raise_for_status.return_value = None
-    monkeypatch.setattr(dc.requests, "get", lambda url, headers: resp)
+    monkeypatch.setattr(
+        dc, "directus_request", lambda method, path, **kw: {"data": [{"field": "a"}, {"field": "b"}]}
+    )
     fields = dc.list_fields("col")
     assert fields == ["a", "b"]
 
 
 def test_fetch_items(monkeypatch):
     monkeypatch.setattr(dc, "DIRECTUS_URL", "http://api")
-    resp = MagicMock()
-    resp.json.return_value = {"data": [{"x": 1}]}
-    resp.raise_for_status.return_value = None
-    monkeypatch.setattr(dc.requests, "get", lambda url, headers: resp)
+    monkeypatch.setattr(dc, "directus_request", lambda m, p, **kw: {"data": [{"x": 1}]})
     items = dc.fetch_items("col")
     assert items == [{"x": 1}]
 
 
 def test_insert_items(monkeypatch):
     monkeypatch.setattr(dc, "DIRECTUS_URL", "http://api")
-    resp = MagicMock()
-    resp.json.return_value = {"data": [1]}
-    resp.raise_for_status.return_value = None
-    monkeypatch.setattr(dc.requests, "post", lambda url, json, headers: resp)
+    called = {}
+
+    def fake_request(method, path, **kw):
+        called["method"] = method
+        called["path"] = path
+        called["payload"] = kw.get("json")
+        return {"data": [1]}
+
+    monkeypatch.setattr(dc, "directus_request", fake_request)
     res = dc.insert_items("col", [1])
+    assert called["method"] == "POST"
+    assert called["path"] == "items/col"
+    assert called["payload"] == {"data": [1]}
     assert res == [1]
+
+
+def test_list_collections(monkeypatch):
+    monkeypatch.setattr(dc, "DIRECTUS_URL", "http://api")
+    monkeypatch.setattr(
+        dc, "directus_request", lambda m, p, **kw: {"data": [{"collection": "c1"}, {"collection": "c2"}]}
+    )
+    assert dc.list_collections() == ["c1", "c2"]
+
+
+def test_create_field(monkeypatch):
+    monkeypatch.setattr(dc, "DIRECTUS_URL", "http://api")
+    captured = {}
+
+    def fake_request(method, path, **kw):
+        captured["method"] = method
+        captured["path"] = path
+        captured["json"] = kw.get("json")
+        return {"data": {"field": "x"}}
+
+    monkeypatch.setattr(dc, "directus_request", fake_request)
+    result = dc.create_field("col", "x", "string")
+    assert captured["method"] == "POST"
+    assert captured["path"] == "fields/col"
+    assert captured["json"]["field"] == "x"
+    assert result == {"field": "x"}
 
 def test_requires_url(monkeypatch):
     monkeypatch.setattr(dc, "DIRECTUS_URL", None)


### PR DESCRIPTION
## Summary
- expand `directus_client` with helpers to list collections, create fields and perform generic requests
- add `directus_tools` package with an interactive wizard for Directus API operations
- integrate the wizard into the CLI menu and subcommands
- document the new Directus wizard
- adjust tests for new directus functionality

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68407df947a88327bae27e334e355c93