### PR TITLE
Fix price history parsing & remove CSV date warnings

### DIFF
--- a/modules/generate_report/excel_dashboard.py
+++ b/modules/generate_report/excel_dashboard.py
@@ -174,7 +174,7 @@ def create_dashboard(output_root: str = "output", *, tickers: Optional[Iterable[
         ia_path = td / "income_annual.csv"
         if ia_path.exists():
             try:
-                df = pd.read_csv(ia_path, index_col=0, parse_dates=True)
+                df = pd.read_csv(ia_path, index_col=0)
                 df = df.reset_index().rename(columns={"index": "Period"})
                 income_ann[ticker] = _strip_timezones(df)
             except Exception:
@@ -184,7 +184,7 @@ def create_dashboard(output_root: str = "output", *, tickers: Optional[Iterable[
         iq_path = td / "income_quarter.csv"
         if iq_path.exists():
             try:
-                df = pd.read_csv(iq_path, index_col=0, parse_dates=True)
+                df = pd.read_csv(iq_path, index_col=0)
                 df = df.reset_index().rename(columns={"index": "Period"})
                 income_qtr[ticker] = _strip_timezones(df)
             except Exception:
@@ -194,7 +194,7 @@ def create_dashboard(output_root: str = "output", *, tickers: Optional[Iterable[
         ba_path = td / "balance_annual.csv"
         if ba_path.exists():
             try:
-                df = pd.read_csv(ba_path, index_col=0, parse_dates=True)
+                df = pd.read_csv(ba_path, index_col=0)
                 df = df.reset_index().rename(columns={"index": "Period"})
                 balance_ann[ticker] = _strip_timezones(df)
             except Exception:
@@ -204,7 +204,7 @@ def create_dashboard(output_root: str = "output", *, tickers: Optional[Iterable[
         bq_path = td / "balance_quarter.csv"
         if bq_path.exists():
             try:
-                df = pd.read_csv(bq_path, index_col=0, parse_dates=True)
+                df = pd.read_csv(bq_path, index_col=0)
                 df = df.reset_index().rename(columns={"index": "Period"})
                 balance_qtr[ticker] = _strip_timezones(df)
             except Exception:
@@ -214,7 +214,7 @@ def create_dashboard(output_root: str = "output", *, tickers: Optional[Iterable[
         ca_path = td / "cash_annual.csv"
         if ca_path.exists():
             try:
-                df = pd.read_csv(ca_path, index_col=0, parse_dates=True)
+                df = pd.read_csv(ca_path, index_col=0)
                 df = df.reset_index().rename(columns={"index": "Period"})
                 cash_ann[ticker] = _strip_timezones(df)
             except Exception:
@@ -224,7 +224,7 @@ def create_dashboard(output_root: str = "output", *, tickers: Optional[Iterable[
         cq_path = td / "cash_quarter.csv"
         if cq_path.exists():
             try:
-                df = pd.read_csv(cq_path, index_col=0, parse_dates=True)
+                df = pd.read_csv(cq_path, index_col=0)
                 df = df.reset_index().rename(columns={"index": "Period"})
                 cash_qtr[ticker] = _strip_timezones(df)
             except Exception:

--- a/modules/generate_report/fallback_data.py
+++ b/modules/generate_report/fallback_data.py
@@ -108,6 +108,9 @@ def yf_full_fetch(symbol: str):
         print(df_price.tail(5).to_string())
 
         # Save to CSV (include Date column)
+        if "Adj Close" not in df_price.columns and "Close" in df_price.columns:
+            df_price["Adj Close"] = df_price["Close"]
+
         df_price_reset = df_price.reset_index()
         price_csv_path = output_dir / "1mo_prices.csv"
         df_price_reset.to_csv(price_csv_path, index=False)
@@ -297,6 +300,8 @@ def enrich_ticker_folder(ticker_dir: Path):
                     for col in ("Dividends", "Stock Splits"):
                         if col in df_price.columns:
                             df_price = df_price.drop(columns=[col])
+                    if "Adj Close" not in df_price.columns and "Close" in df_price.columns:
+                        df_price["Adj Close"] = df_price["Close"]
                     df_price_reset = df_price.reset_index()
                     df_price_reset.to_csv(csv_path, index=False)
                     new_source = "yfinance.history"

--- a/modules/generate_report/metadata_checker.py
+++ b/modules/generate_report/metadata_checker.py
@@ -103,7 +103,13 @@ def fetch_1mo_prices_yf(symbol: str) -> pd.DataFrame:
     # Drop unwanted columns
     hist = hist.drop(columns=[c for c in ("Dividends", "Stock Splits") if c in hist.columns])
     hist.reset_index(inplace=True)  # Make 'Date' a column again
-    return hist.loc[:, ["Date", "Open", "High", "Low", "Close", "Adj Close", "Volume"]]
+
+    # Ensure expected columns are present; some sources may miss 'Adj Close'
+    if "Adj Close" not in hist.columns and "Close" in hist.columns:
+        hist["Adj Close"] = hist["Close"]
+
+    desired_cols = ["Date", "Open", "High", "Low", "Close", "Adj Close", "Volume"]
+    return hist.loc[:, [c for c in desired_cols if c in hist.columns]]
 
 
 def fetch_fin_stmt_from_yf(symbol: str, stmt_key: str) -> pd.DataFrame:


### PR DESCRIPTION
## Summary
- stop pandas from trying to parse financial CSV indexes as dates
- gracefully handle missing `Adj Close` when re-fetching price history

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684081aec19883279d314cbeb003a6fe