### PR TITLE
Fix Directus wizard when no config

### DIFF
--- a/modules/data/directus_client.py
+++ b/modules/data/directus_client.py
@@ -10,6 +10,14 @@ DIRECTUS_URL = os.getenv("DIRECTUS_URL")
 DIRECTUS_TOKEN = os.getenv("DIRECTUS_TOKEN")
 
 
+def reload_env() -> None:
+    """Reload Directus environment variables from ``config/.env``."""
+    load_settings()  # ensures .env is loaded
+    global DIRECTUS_URL, DIRECTUS_TOKEN
+    DIRECTUS_URL = os.getenv("DIRECTUS_URL")
+    DIRECTUS_TOKEN = os.getenv("DIRECTUS_TOKEN")
+
+
 def _headers():
     if DIRECTUS_TOKEN:
         return {"Authorization": f"Bearer {DIRECTUS_TOKEN}"}

--- a/modules/management/directus_tools/directus_wizard.py
+++ b/modules/management/directus_tools/directus_wizard.py
@@ -2,12 +2,24 @@ import json
 
 from modules.data import directus_client as dc
 
+try:
+    from modules.management.settings_manager.wizards.directus_setup import (
+        run_wizard as _directus_setup,
+    )
+except Exception:  # pragma: no cover - wizard optional
+    _directus_setup = None
+
 
 def run_directus_wizard() -> None:
     """Interactive wizard for common Directus API operations."""
     if not dc.DIRECTUS_URL:
-        print("DIRECTUS_URL not configured in config/.env\n")
-        return
+        print("DIRECTUS_URL not configured in config/.env")
+        if _directus_setup:
+            _directus_setup()
+            dc.reload_env()
+        if not dc.DIRECTUS_URL:
+            print()
+            return
 
     while True:
         print("\n=== Directus API Wizard ===")


### PR DESCRIPTION
## Summary
- automatically prompt for Directus details when running Directus wizard without config
- allow reloading environment variables via `directus_client.reload_env`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68409c49d23483278e28e2e8b21217bf