### PR TITLE
Add additional unit tests

### DIFF
--- a/tests/test_excel_dashboard.py
+++ b/tests/test_excel_dashboard.py
@@ -1,5 +1,10 @@
 import pandas as pd
-from generate_report.excel_dashboard import _col_to_letter, _safe_concat_normal, _transpose_financials
+from generate_report.excel_dashboard import (
+    _col_to_letter,
+    _safe_concat_normal,
+    _transpose_financials,
+    _strip_timezones,
+)
 
 
 def test_col_to_letter_basic():
@@ -54,3 +59,11 @@ def test_transpose_financials():
     assert second_block.iloc[1, 1] == "EPS"
     assert second_block.iloc[1, 2] == 3
     assert pd.isna(second_block.iloc[1, 3])
+
+
+def test_strip_timezones_removes_tz():
+    idx = pd.DatetimeIndex(["2024-01-01"], tz="UTC")
+    df = pd.DataFrame({"val": [1], "ts": pd.Series([pd.Timestamp("2024-01-02", tz="UTC")])}, index=idx)
+    result = _strip_timezones(df.copy())
+    assert result.index.tz is None
+    assert result["ts"].dtype == "datetime64[ns]"

--- a/tests/test_group_analysis.py
+++ b/tests/test_group_analysis.py
@@ -1,0 +1,22 @@
+import pandas as pd
+import modules.management.group_analysis.group_analysis as ga
+
+
+def test_load_groups_directus(monkeypatch):
+    records = [{"Group": "G", "Ticker": "AAA", "Name": "Alpha"}]
+    monkeypatch.setattr(ga, "USE_DIRECTUS", True)
+    monkeypatch.setattr(ga, "fetch_items", lambda c: records)
+    df = ga.load_groups("dummy.xlsx")
+    assert list(df.columns) == ga.COLUMNS
+    assert df.iloc[0]["Ticker"] == "AAA"
+
+
+def test_save_groups_directus(monkeypatch):
+    monkeypatch.setattr(ga, "USE_DIRECTUS", True)
+    monkeypatch.setattr(ga, "list_fields", lambda c: ["Group", "Ticker", "Name"])
+    captured = {}
+    monkeypatch.setattr(ga, "insert_items", lambda c, recs: captured.setdefault("rec", recs))
+    df = pd.DataFrame({"Group": ["G"], "Ticker": ["AAA"], "Name": ["Alpha"], "Extra": [1]})
+    ga.save_groups(df, "dummy.xlsx")
+    assert captured["rec"] == [{"Group": "G", "Ticker": "AAA", "Name": "Alpha"}]
+

--- a/tests/test_interactive_profile.py
+++ b/tests/test_interactive_profile.py
@@ -1,0 +1,13 @@
+import pandas as pd
+import modules.data.compare as cmp
+
+
+def test_interactive_profile_choose_yf(monkeypatch):
+    obb_df = pd.DataFrame([{"longName": "Alpha", "sector": "Tech", "industry": "Soft", "marketCap": 1, "website": "a"}])
+    yf_df = pd.DataFrame([{"longName": "Alpha", "sector": "Finance", "industry": "Bank", "marketCap": 2, "website": "b"}])
+    monkeypatch.setattr(cmp, "fetch_profile_openbb", lambda s: obb_df)
+    monkeypatch.setattr(cmp, "fetch_profile_yf", lambda s: yf_df)
+    monkeypatch.setattr("builtins.input", lambda *_: "y")
+    result = cmp.interactive_profile("AAA")
+    assert result.iloc[0]["sector"] == "Finance"
+


### PR DESCRIPTION
## Summary
- expand dashboard tests to cover timezone stripping
- add new tests for group analysis utilities
- cover interactive_profile selection logic

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6840ac3dae1083279b489df1f628ed2e