### PR TITLE
Improve data package exports and CLI

### DIFF
--- a/modules/data/__init__.py
+++ b/modules/data/__init__.py
@@ -1,1 +1,37 @@
-"""Data utilities package."""
+"""Unified access to common data helpers.
+
+This package exposes a selection of frequently used functions from the
+individual submodules so callers can simply ``import data`` and reference
+them directly.  All submodules remain importable on their own.
+"""
+
+from .fetching import fetch_basic_stock_data, BASIC_FIELDS
+from .directus_client import (
+    list_collections,
+    list_fields,
+    fetch_items,
+    insert_items,
+    create_field,
+    directus_request,
+    reload_env,
+)
+from .term_mapper import load_mapping, save_mapping, resolve_term, add_alias
+from .compare import interactive_profile, diff_dict
+
+__all__ = [
+    "fetch_basic_stock_data",
+    "BASIC_FIELDS",
+    "list_collections",
+    "list_fields",
+    "fetch_items",
+    "insert_items",
+    "create_field",
+    "directus_request",
+    "reload_env",
+    "load_mapping",
+    "save_mapping",
+    "resolve_term",
+    "add_alias",
+    "interactive_profile",
+    "diff_dict",
+]

--- a/modules/data/compare.py
+++ b/modules/data/compare.py
@@ -1,4 +1,5 @@
 import logging
+import sys
 from typing import Dict, Tuple
 
 import pandas as pd
@@ -86,4 +87,22 @@ def interactive_profile(symbol: str) -> pd.DataFrame:
     if choice == 'y':
         return yf_df
     return obb_df
+
+
+def _main(argv: list[str]) -> int:
+    """Entry point for ``python -m data.compare``."""
+    if len(argv) != 2:
+        print("Usage: python -m data.compare <TICKER>")
+        return 1
+    symbol = argv[1].upper()
+    df = interactive_profile(symbol)
+    if df.empty:
+        print("No data available.")
+        return 1
+    print(df.to_string(index=False))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(_main(sys.argv))
 


### PR DESCRIPTION
## Summary
- expose key helper functions at `data` package level
- add command-line interface for `data.compare`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6840afd73884832798ef22230d9632c9