### PR TITLE
Improve management module exports

### DIFF
--- a/docs/overview.md
+++ b/docs/overview.md
@@ -19,6 +19,10 @@ Tools for maintaining local data files:
 - `group_analysis` – manage related tickers in `groups.xlsx`.
 - `note_manager` – simple Markdown note system supporting `[[wikilinks]]`.
 
+Importing `modules.management` exposes convenience functions such as
+`run_portfolio_manager()` and `run_group_analysis()` for launching each tool
+directly.
+
 ### `modules.data`
 Lower-level helpers used across the app:
 - `fetching.py` – small wrappers around yfinance and HTTP calls.

--- a/modules/management/__init__.py
+++ b/modules/management/__init__.py
@@ -1,1 +1,15 @@
-"""Management subpackage."""
+"""Convenience wrappers for management tools."""
+
+from .portfolio_manager.portfolio_manager import main as run_portfolio_manager
+from .group_analysis.group_analysis import main as run_group_analysis
+from .note_manager.note_manager import run_note_manager
+from .settings_manager.settings_manager import run_settings_manager
+from .directus_tools.directus_wizard import run_directus_wizard
+
+__all__ = [
+    "run_portfolio_manager",
+    "run_group_analysis",
+    "run_note_manager",
+    "run_settings_manager",
+    "run_directus_wizard",
+]

--- a/tests/test_management_package.py
+++ b/tests/test_management_package.py
@@ -1,0 +1,15 @@
+from modules.management import (
+    run_portfolio_manager,
+    run_group_analysis,
+    run_note_manager,
+    run_settings_manager,
+    run_directus_wizard,
+)
+
+
+def test_management_exports_callable():
+    assert callable(run_portfolio_manager)
+    assert callable(run_group_analysis)
+    assert callable(run_note_manager)
+    assert callable(run_settings_manager)
+    assert callable(run_directus_wizard)


### PR DESCRIPTION
## Summary
- expose convenience run_* functions from `modules.management`
- document the new exports in the codebase overview
- test the new management package API

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6840affd50b883279bb53e6c4e452db8