### PR TITLE
Add correlation matrix utility

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ python scripts/main.py dashboard
 ## Project Layout
 
 - `config/` – configuration files including `finance_api.yaml`, `term_mapping.json`, `.env` and `settings.json`.
-- `modules/` – reusable Python modules with helpers such as `sector_counts()`.
+- `modules/` – reusable Python modules with helpers such as `sector_counts()` and `correlation_matrix()`.
 - `scripts/` – entry-point scripts like `main.py`.
 
 ### Comparing OpenBB and yfinance data

--- a/modules/analytics/__init__.py
+++ b/modules/analytics/__init__.py
@@ -21,3 +21,13 @@ def sector_counts(df: pd.DataFrame) -> pd.DataFrame:
         return pd.DataFrame()
     counts = df["Sector"].fillna("Unknown").value_counts().rename_axis("Sector")
     return counts.reset_index(name="Count")
+
+
+def correlation_matrix(df: pd.DataFrame) -> pd.DataFrame:
+    """Return Pearson correlation matrix for numeric columns."""
+    if df is None or df.empty:
+        return pd.DataFrame()
+    numeric_cols = [c for c in df.columns if pd.api.types.is_numeric_dtype(df[c])]
+    if len(numeric_cols) < 2:
+        return pd.DataFrame()
+    return df[numeric_cols].corr()

--- a/tests/test_analysis.py
+++ b/tests/test_analysis.py
@@ -1,5 +1,7 @@
 import pandas as pd
 from analytics import portfolio_summary, sector_counts
+import pytest
+from analytics import correlation_matrix
 
 
 def test_portfolio_summary_numeric_columns():
@@ -32,3 +34,18 @@ def test_sector_counts_basic():
 def test_sector_counts_no_sector_column():
     df = pd.DataFrame({"Ticker": ["A", "B"]})
     assert sector_counts(df).empty
+
+def test_correlation_matrix_basic():
+    df = pd.DataFrame({
+        "A": [1, 2, 3],
+        "B": [2, 4, 6],
+        "Label": ["x", "y", "z"],
+    })
+    corr = correlation_matrix(df)
+    assert list(corr.index) == ["A", "B"]
+    assert corr.loc["A", "B"] == pytest.approx(1.0)
+
+
+def test_correlation_matrix_insufficient_data():
+    df = pd.DataFrame({"A": [1, 2, 3]})
+    assert correlation_matrix(df).empty


### PR DESCRIPTION
## Summary
- implement `correlation_matrix` in analytics
- document the new helper in README
- test correlation matrix behavior

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6840b00f9a508327b68fe8f6a2dbab66