### PR TITLE
Enable configurable output directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,7 @@ python scripts/main.py notes
 ```
 Notes support Obsidian-style `[[wikilinks]]` for linking between files.
 Use the **Notes Directory** wizard in the Settings Manager if you want to store notes elsewhere.
+The report **Output Directory** can likewise be set via the corresponding wizard or `OUTPUT_DIR` environment variable.
 
 ### Configuration & Secrets
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -18,13 +18,14 @@ DIRECTUS_TOKEN=secret-token
 # Optional collection names
 DIRECTUS_PORTFOLIO_COLLECTION=portfolio
 DIRECTUS_GROUPS_COLLECTION=groups
+OUTPUT_DIR=output
 ```
 To obtain an OpenBB API token visit the
 [OpenBB documentation](https://docs.openbb.co/platform/getting_started/api_requests)
 and sign up for an account. Once acquired, run the **OpenBB API Token** wizard
 inside the Settings Manager to store the token. The Settings Manager also
 provides wizards for configuring your **Directus connection** and **Notes
-directory** so you rarely need to edit this file manually.
+directory**. Another wizard sets the **Output Directory** used for reports.
 `modules.config_utils` automatically loads this file using [python-dotenv](https://github.com/theskumar/python-dotenv) whenever `load_settings()` is called.
 
 ## Creating `config/settings.json`

--- a/docs/report_generation.md
+++ b/docs/report_generation.md
@@ -25,7 +25,7 @@ Each ticker directory contains:
 - `report.md` – markdown summary listing the data sources.
 - `metadata.json` – metadata describing the source and fetch time for every file.
 
-An Excel workbook named `dashboard_<TIMESTAMP>.xlsx` is created from these CSVs and placed in the `output` folder.
+An Excel workbook named `dashboard_<TIMESTAMP>.xlsx` is created from these CSVs and placed in the output folder. The folder defaults to `output` but can be customized via the `OUTPUT_DIR` environment variable or the **Output Directory** wizard.
 
 ## Command Example
 

--- a/modules/config_utils.py
+++ b/modules/config_utils.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import os
 from pathlib import Path
 from typing import Any, Dict
 
@@ -54,3 +55,8 @@ def save_env(env: Dict[str, str]) -> None:
     with open(ENV_PATH, "w", encoding="utf-8") as f:
         for key, val in env.items():
             f.write(f"{key}={val}\n")
+
+
+def get_output_dir() -> Path:
+    """Return output directory path from ``OUTPUT_DIR`` env variable."""
+    return Path(os.getenv("OUTPUT_DIR", "output"))

--- a/modules/generate_report/__init__.py
+++ b/modules/generate_report/__init__.py
@@ -79,7 +79,7 @@ def run_generate_report():
     # ─────────────────────────────────────────────────────────────────
     # Now create and open the Excel dashboard. Any exception will be printed.
     try:
-        create_and_open_dashboard(output_root="output", tickers=tickers)
+        create_and_open_dashboard(tickers=tickers)
     except Exception as e:
         print(f"[ERROR] Could not create/open Excel dashboard: {e}")
 

--- a/modules/generate_report/excel_dashboard.py
+++ b/modules/generate_report/excel_dashboard.py
@@ -92,8 +92,10 @@ def _safe_concat_normal(ticker_dfs: dict[str, pd.DataFrame]) -> pd.DataFrame:
 
 from typing import Iterable, Optional
 
+from modules.config_utils import get_output_dir
 
-def create_dashboard(output_root: str = "output", *, tickers: Optional[Iterable[str]] = None) -> Path:
+
+def create_dashboard(output_root: str | None = None, *, tickers: Optional[Iterable[str]] = None) -> Path:
     """
     1) Find subfolders under output_root (one per ticker).
     2) Read these CSVs if present:
@@ -126,6 +128,9 @@ def create_dashboard(output_root: str = "output", *, tickers: Optional[Iterable[
     Returns:
         Path to the newly created .xlsx file.
     """
+    if output_root is None:
+        output_root = str(get_output_dir())
+
     root = Path(output_root)
     if not root.exists() or not root.is_dir():
         raise FileNotFoundError(f"Output folder '{output_root}' not found.")
@@ -429,7 +434,7 @@ def show_dashboard_in_excel(dashboard_path: Path):
         subprocess.call(["xdg-open", str(dashboard_path)])
 
 
-def create_and_open_dashboard(output_root: str = "output", *, tickers: Optional[Iterable[str]] = None):
+def create_and_open_dashboard(output_root: str | None = None, *, tickers: Optional[Iterable[str]] = None):
     """
     Create an Excel dashboard (with named Tables) and open it automatically.
     """

--- a/modules/generate_report/fallback_data.py
+++ b/modules/generate_report/fallback_data.py
@@ -16,6 +16,8 @@ import os
 import time
 from pathlib import Path
 
+from modules.config_utils import get_output_dir
+
 import pandas as pd
 import requests
 import yfinance as yf
@@ -411,10 +413,12 @@ def enrich_ticker_folder(ticker_dir: Path):
 # ─── Step 4: Directory scan entry point ───────────────────────────────────────────────────────────
 #
 
-def run_fallback_data(tickers=None):
+def run_fallback_data(tickers=None, output_root: str | None = None):
     """Run fallback enrichment for all or selected tickers."""
     project_root = Path(__file__).resolve().parents[2]
-    output_root = project_root / "output"
+    if output_root is None:
+        output_root = str(get_output_dir())
+    output_root = project_root / output_root if not Path(output_root).is_absolute() else Path(output_root)
 
     if not output_root.exists() or not output_root.is_dir():
         print(f"[ERROR] '{output_root}' does not exist or is not a directory.")

--- a/modules/generate_report/metadata_checker.py
+++ b/modules/generate_report/metadata_checker.py
@@ -13,6 +13,8 @@ import json
 import time
 from pathlib import Path
 
+from modules.config_utils import get_output_dir
+
 import pandas as pd
 import yfinance as yf
 import requests
@@ -275,10 +277,12 @@ def enrich_ticker_folder(ticker_dir: Path):
         print(f"\n  • No updates made for {ticker_dir.name} (no ERROR entries found).")
 
 
-def run_for_tickers(tickers, output_root="output"):
+def run_for_tickers(tickers, output_root: str | None = None):
     """Run metadata enrichment only for the specified ticker list."""
     project_root = Path(__file__).resolve().parents[2]
-    out_root = project_root / output_root
+    if output_root is None:
+        output_root = str(get_output_dir())
+    out_root = project_root / output_root if not Path(output_root).is_absolute() else Path(output_root)
 
     if not out_root.exists() or not out_root.is_dir():
         print(f"[ERROR] '{out_root}' does not exist or is not a directory.")
@@ -299,9 +303,11 @@ def run_for_tickers(tickers, output_root="output"):
     print("\n[Metadata Enricher] Done.\n")
 
 
-def main():
+def main(output_root: str | None = None):
     project_root = Path(__file__).resolve().parents[2]
-    output_root = project_root / "output"
+    if output_root is None:
+        output_root = str(get_output_dir())
+    output_root = project_root / output_root if not Path(output_root).is_absolute() else Path(output_root)
 
     if not output_root.exists() or not output_root.is_dir():
         print(f"[ERROR] '{output_root}' does not exist or is not a directory.")

--- a/modules/generate_report/report_generator.py
+++ b/modules/generate_report/report_generator.py
@@ -15,11 +15,13 @@ import json
 import pandas as pd
 import matplotlib.pyplot as plt
 
+from modules.config_utils import get_output_dir
+
 # Delay heavy OpenBB import until needed
 obb = None
 
 
-def fetch_and_compile(symbol: str, base_output: str = "output"):
+def fetch_and_compile(symbol: str, base_output: str | None = None):
     """
     1) Create output/<symbol>/
     2) Fetch company profile, save as profile.csv, record source & source_url
@@ -32,6 +34,9 @@ def fetch_and_compile(symbol: str, base_output: str = "output"):
     if obb is None:
         from openbb import obb as _obb
         obb = _obb
+
+    if base_output is None:
+        base_output = str(get_output_dir())
 
     symbol = symbol.upper()
     ticker_dir = os.path.join(base_output, symbol)

--- a/modules/management/settings_manager/wizards/output_dir.py
+++ b/modules/management/settings_manager/wizards/output_dir.py
@@ -1,0 +1,15 @@
+"""Wizard to set the report output directory."""
+
+from modules.config_utils import load_env, save_env
+
+LABEL = "Output Directory"
+
+
+def run_wizard() -> None:
+    print("\n=== Output Directory Setup ===")
+    env = load_env()
+    current = env.get("OUTPUT_DIR", "output")
+    path = input(f"Output directory [{current}]: ").strip() or current
+    env["OUTPUT_DIR"] = path
+    save_env(env)
+    print(f"Output directory saved to config/.env as '{path}'.\n")

--- a/tests/test_output_dir_env.py
+++ b/tests/test_output_dir_env.py
@@ -1,0 +1,53 @@
+import pandas as pd
+
+import modules.generate_report.report_generator as rg
+import modules.generate_report.excel_dashboard as ed
+
+class Dummy:
+    def __init__(self, df):
+        self._df = df
+
+    def to_df(self):
+        return self._df
+
+
+def test_env_output_dir(tmp_path, monkeypatch):
+    profile_df = pd.DataFrame({"symbol": ["AAA"]})
+    price_df = pd.DataFrame({"Date": pd.date_range("2023-01-01", periods=1)})
+    stmt_df = pd.DataFrame({"Revenue": [1]}, index=pd.Index(["2023"], name="Period"))
+
+    class FakeEquity:
+        def __init__(self):
+            class _Profile:
+                def __call__(self, symbol):
+                    return Dummy(profile_df)
+
+            class _Price:
+                def historical(self, symbol, period, provider=None):
+                    return Dummy(price_df)
+
+            class _Fundamental:
+                def income(self, symbol, period):
+                    return Dummy(stmt_df)
+
+                def balance(self, symbol, period):
+                    return Dummy(stmt_df)
+
+                def cash(self, symbol, period):
+                    return Dummy(stmt_df)
+
+            self.profile = _Profile()
+            self.price = _Price()
+            self.fundamental = _Fundamental()
+
+    class FakeOBB:
+        def __init__(self):
+            self.equity = FakeEquity()
+
+    monkeypatch.setattr(rg, "obb", FakeOBB())
+    monkeypatch.setenv("OUTPUT_DIR", str(tmp_path))
+    rg.fetch_and_compile("AAA")
+    assert (tmp_path / "AAA" / "profile.csv").is_file()
+
+    dash = ed.create_dashboard()
+    assert dash.is_file()


### PR DESCRIPTION
## Summary
- allow output directory to be configured via `OUTPUT_DIR`
- add Output Directory wizard
- document new setting in README and docs
- respect `OUTPUT_DIR` in report generation modules
- test output directory environment variable

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6840b0461b5c83278e62df832cab8644