### PR TITLE
Add FMP API key wizard and support

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ The report **Output Directory** can likewise be set via the corresponding wizard
 
 ### Configuration & Secrets
 
-Place API keys (Directus, OpenBB, OpenAI) in `config/.env` and preferences in `config/settings.json`. These files are ignored by Git and are loaded automatically using `python-dotenv`.
+Place API keys (Directus, OpenBB, FMP, OpenAI) in `config/.env` and preferences in `config/settings.json`. These files are ignored by Git and are loaded automatically using `python-dotenv`.
 
 ### End-to-End Tests
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -12,6 +12,7 @@ Example contents:
 ```env
 # API keys
 OPENBB_TOKEN=your-openbb-key
+FMP_API_KEY=your-fmp-key
 DIRECTUS_URL=https://your-directus.example.com
 DIRECTUS_TOKEN=secret-token
 
@@ -26,6 +27,9 @@ and sign up for an account. Once acquired, run the **OpenBB API Token** wizard
 inside the Settings Manager to store the token. The Settings Manager also
 provides wizards for configuring your **Directus connection** and **Notes
 directory**. Another wizard sets the **Output Directory** used for reports.
+Similarly, obtain a Financial Modeling Prep key from
+[fmp](https://financialmodelingprep.com/) and run the **FMP API Key** wizard
+to store it in `.env`.
 `modules.config_utils` automatically loads this file using [python-dotenv](https://github.com/theskumar/python-dotenv) whenever `load_settings()` is called.
 
 ## Creating `config/settings.json`

--- a/modules/config_utils.py
+++ b/modules/config_utils.py
@@ -60,3 +60,12 @@ def save_env(env: Dict[str, str]) -> None:
 def get_output_dir() -> Path:
     """Return output directory path from ``OUTPUT_DIR`` env variable."""
     return Path(os.getenv("OUTPUT_DIR", "output"))
+
+
+def add_fmp_api_key(url: str) -> str:
+    """Append the FMP API key as a query parameter if configured."""
+    key = os.getenv("FMP_API_KEY")
+    if not key:
+        return url
+    sep = "&" if "?" in url else "?"
+    return f"{url}{sep}apikey={key}"

--- a/modules/data/fetching.py
+++ b/modules/data/fetching.py
@@ -6,6 +6,8 @@ import pandas as pd
 import requests
 import yfinance as yf
 
+from modules.config_utils import add_fmp_api_key
+
 from .term_mapper import resolve_term
 
 BASIC_FIELDS = [
@@ -39,7 +41,7 @@ def _parse_yf_info(info: dict, ticker: str) -> dict:
 
 def _fetch_from_fmp(ticker: str) -> dict:
     """Return BASIC_FIELDS dict using FMP profile endpoint."""
-    url = FMP_PROFILE_URL.format(symbol=ticker)
+    url = add_fmp_api_key(FMP_PROFILE_URL.format(symbol=ticker))
     resp = requests.get(url)
     resp.raise_for_status()
     data = resp.json()

--- a/modules/generate_report/fallback_data.py
+++ b/modules/generate_report/fallback_data.py
@@ -15,7 +15,7 @@ import json
 import os
 from pathlib import Path
 
-from modules.config_utils import get_output_dir
+from modules.config_utils import get_output_dir, add_fmp_api_key
 
 import pandas as pd
 import requests
@@ -171,7 +171,7 @@ def fetch_profile_from_fmp(symbol: str) -> pd.DataFrame:
     at least these columns: symbol, longName, sector, industry, marketCap, website.
     Raises ValueError if no data is returned.
     """
-    url = f"{FMP_BASE}/profile/{symbol}"
+    url = add_fmp_api_key(f"{FMP_BASE}/profile/{symbol}")
     resp = requests.get(url)
     resp.raise_for_status()
     data = resp.json()
@@ -203,7 +203,7 @@ def fetch_fmp_statement(symbol: str, stmt_endpoint: str, period: str) -> pd.Data
     'balance-sheet-statement', 'cash-flow-statement'. Period: 'annual' or 'quarter'.
     Returns a DataFrame indexed by date if successful; raises ValueError otherwise.
     """
-    url = f"{FMP_BASE}/{stmt_endpoint}/{symbol}?period={period}"
+    url = add_fmp_api_key(f"{FMP_BASE}/{stmt_endpoint}/{symbol}?period={period}")
     resp = requests.get(url)
     resp.raise_for_status()
     data = resp.json()

--- a/modules/generate_report/metadata_checker.py
+++ b/modules/generate_report/metadata_checker.py
@@ -12,7 +12,7 @@ metadata.json with new source, source_url, and fetched_at timestamp.
 import json
 from pathlib import Path
 
-from modules.config_utils import get_output_dir
+from modules.config_utils import get_output_dir, add_fmp_api_key
 
 import pandas as pd
 import yfinance as yf
@@ -39,7 +39,7 @@ def fetch_profile_from_yf(symbol: str) -> pd.DataFrame:
     # If yfinance.info is empty or missing longName, try FMP for profile
     if not info or info.get("longName") is None:
         # Fallback to FMP
-        url = f"{FMP_BASE}/profile/{symbol}"
+        url = add_fmp_api_key(f"{FMP_BASE}/profile/{symbol}")
         resp = requests.get(url)
         resp.raise_for_status()
         data = resp.json()
@@ -134,7 +134,7 @@ def fetch_fmp_statement(symbol: str, stmt_endpoint: str, period: str) -> pd.Data
     stmt_endpoint: 'income-statement', 'balance-sheet-statement', or 'cash-flow-statement'.
     period: 'annual' or 'quarter' 
     """
-    url = f"{FMP_BASE}/{stmt_endpoint}/{symbol}?period={period}"
+    url = add_fmp_api_key(f"{FMP_BASE}/{stmt_endpoint}/{symbol}?period={period}")
     resp = requests.get(url)
     resp.raise_for_status()
     data = resp.json()

--- a/modules/management/settings_manager/wizards/fmp_key.py
+++ b/modules/management/settings_manager/wizards/fmp_key.py
@@ -1,0 +1,18 @@
+"""Wizard to set the Financial Modeling Prep API key."""
+
+from modules.config_utils import load_env, save_env
+
+LABEL = "FMP API Key"
+
+
+def run_wizard() -> None:
+    print("\n=== FMP API Key Setup ===")
+    print("Obtain a free API key at https://financialmodelingprep.com\n")
+    key = input("Enter FMP API key: ").strip()
+    if not key:
+        print("No key provided.\n")
+        return
+    env = load_env()
+    env["FMP_API_KEY"] = key
+    save_env(env)
+    print("API key saved to config/.env.\n")


### PR DESCRIPTION
## Summary
- create `FMP API Key` setup wizard
- append FMP API key to requests when configured
- document new key in README and configuration guide

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68410e9590548327ba840b796f5ffe41