### PR TITLE
Add quick setup wizard

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ python scripts/main.py notes
 Notes support Obsidian-style `[[wikilinks]]` for linking between files.
 Use the **Notes Directory** wizard in the Settings Manager if you want to store notes elsewhere.
 The report **Output Directory** can likewise be set via the corresponding wizard or `OUTPUT_DIR` environment variable.
+If these variables are already set in your shell, the **Quick Setup** wizard can save them all to `.env`.
 
 ### Configuration & Secrets
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -25,11 +25,12 @@ To obtain an OpenBB API token visit the
 [OpenBB documentation](https://docs.openbb.co/platform/getting_started/api_requests)
 and sign up for an account. Once acquired, run the **OpenBB API Token** wizard
 inside the Settings Manager to store the token. The Settings Manager also
-provides wizards for configuring your **Directus connection** and **Notes
-directory**. Another wizard sets the **Output Directory** used for reports.
-Similarly, obtain a Financial Modeling Prep key from
-[fmp](https://financialmodelingprep.com/) and run the **FMP API Key** wizard
-to store it in `.env`.
+ provides wizards for configuring your **Directus connection** and **Notes
+ directory**. Another wizard sets the **Output Directory** used for reports.
+ Similarly, obtain a Financial Modeling Prep key from
+ [fmp](https://financialmodelingprep.com/) and run the **FMP API Key** wizard
+ to store it in `.env`. If you already exported these variables in your shell,
+ the **Quick Setup** wizard can write them all to `.env` in one go.
 `modules.config_utils` automatically loads this file using [python-dotenv](https://github.com/theskumar/python-dotenv) whenever `load_settings()` is called.
 
 ## Creating `config/settings.json`

--- a/modules/management/settings_manager/wizards/quick_setup.py
+++ b/modules/management/settings_manager/wizards/quick_setup.py
@@ -1,0 +1,37 @@
+"""Populate .env using existing environment variables."""
+
+import os
+
+from modules.config_utils import load_env, save_env
+
+LABEL = "Quick Setup"
+
+
+def run_wizard() -> None:
+    print("\n=== Quick Setup ===")
+    env = load_env()
+
+    keys = [
+        "OPENBB_TOKEN",
+        "FMP_API_KEY",
+        "OPENAI_API_KEY",
+        "NOTES_DIR",
+        "OUTPUT_DIR",
+        "DIRECTUS_URL",
+        "DIRECTUS_TOKEN",
+        "DIRECTUS_PORTFOLIO_COLLECTION",
+        "DIRECTUS_GROUPS_COLLECTION",
+    ]
+
+    found = False
+    for key in keys:
+        val = os.getenv(key)
+        if val:
+            env[key] = val
+            found = True
+    if found:
+        save_env(env)
+        print("Environment variables saved to config/.env.\n")
+    else:
+        print("No matching environment variables found.\n")
+


### PR DESCRIPTION
## Summary
- provide Quick Setup wizard to populate `.env` using existing environment variables
- document Quick Setup wizard

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684112a984dc8327b11a86b2a7d6b567