### PR TITLE
Improve run_tests script

### DIFF
--- a/scripts/run_tests.py
+++ b/scripts/run_tests.py
@@ -17,12 +17,20 @@ def main() -> None:
     repo_root = Path(__file__).resolve().parents[1]
     tests_dir = repo_root / "tests"
     test_files = sorted(tests_dir.glob("test_*.py"))
+    failures: list[str] = []
+
     for test_file in test_files:
         print(f"Running {test_file.name}")
-        subprocess.run(
+        result = subprocess.run(
             [sys.executable, "-m", "pytest", "-q", str(test_file)],
-            check=True,
+            check=False,
         )
+        if result.returncode != 0:
+            failures.append(test_file.name)
+
+    if failures:
+        print(f"\n{len(failures)} test files failed: {', '.join(failures)}")
+        sys.exit(1)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- make run_tests keep running after a failing file and return overall status

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68411ae912a483278e1591fe13baa0d4