### PR TITLE
Improve CLI UX

### DIFF
--- a/UI_IMPROVEMENT_REPORT.md
+++ b/UI_IMPROVEMENT_REPORT.md
@@ -1,0 +1,29 @@
+# UI Improvement Report
+
+The Fundalyze project uses a command line interface exposed via `scripts/main.py` and various management modules. The following usability issues were identified:
+
+- **Inconsistent error messages and prompts**: menus printed varying phrases like "Invalid choice", "Invalid selection" or numeric ranges (e.g. `Enter 1/2/3/4/5`).
+- **Lack of clear cancel instructions** when adding tickers or groups.
+- **Minimal CLI help**: the main entry script lacked usage examples and a version flag.
+
+## Refactoring Steps
+
+1. Added a helper in `modules/interface.py` for standardized invalid choice messages.
+2. Updated all interactive modules to import `print_invalid_choice` and replaced bespoke messages.
+3. Clarified prompts for adding tickers to mention pressing Enter to cancel.
+4. Revised menu prompts to use `Select an option [n]` wording.
+5. Enhanced `scripts/main.py` argument parser with examples, version flag and `RawTextHelpFormatter`.
+
+## Affected Files
+
+- `modules/interface.py`
+- `scripts/main.py`
+- `modules/management/portfolio_manager/portfolio_manager.py`
+- `modules/management/group_analysis/group_analysis.py`
+- `modules/management/note_manager/note_manager.py`
+- `modules/management/directus_tools/directus_wizard.py`
+- `modules/management/settings_manager/settings_manager.py`
+- `modules/management/settings_manager/wizards/timezone.py`
+- `modules/generate_report/__init__.py`
+
+These changes ensure consistent feedback across the CLI and provide clearer guidance for new users.

--- a/modules/generate_report/__init__.py
+++ b/modules/generate_report/__init__.py
@@ -13,6 +13,7 @@ from modules.management.group_analysis.group_analysis import (
     load_groups,
     GROUPS_FILE,
 )
+from modules.interface import print_invalid_choice
 
 
 def _select_tickers() -> list[str]:
@@ -45,12 +46,12 @@ def _select_tickers() -> list[str]:
             grp = names[int(sel) - 1]
             df = groups[groups["Group"] == grp]
             return df["Ticker"].dropna().astype(str).str.upper().unique().tolist()
-        print("Invalid selection.\n")
+        print_invalid_choice()
         return []
 
     if choice == "4":
         return []
-    print("Invalid choice.\n")
+    print_invalid_choice()
     return []
 
 

--- a/modules/interface.py
+++ b/modules/interface.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 import pandas as pd
 from tabulate import tabulate
 
+INVALID_CHOICE_MSG = "Invalid choice. Please select a valid option.\n"
+
 
 def print_table(df: pd.DataFrame, *, showindex: bool = False) -> None:
     """Pretty-print a DataFrame using :mod:`tabulate`."""
@@ -10,3 +12,8 @@ def print_table(df: pd.DataFrame, *, showindex: bool = False) -> None:
         print("(no data)")
         return
     print(tabulate(df, headers="keys", tablefmt="fancy_grid", showindex=showindex))
+
+
+def print_invalid_choice() -> None:
+    """Standard message for invalid menu selections."""
+    print(INVALID_CHOICE_MSG)

--- a/modules/management/directus_tools/directus_wizard.py
+++ b/modules/management/directus_tools/directus_wizard.py
@@ -1,5 +1,7 @@
 import json
 
+from modules.interface import print_invalid_choice
+
 from modules.data import directus_client as dc
 
 try:
@@ -69,4 +71,4 @@ def run_directus_wizard() -> None:
         elif choice == "6":
             break
         else:
-            print("Invalid choice.\n")
+            print_invalid_choice()

--- a/modules/management/group_analysis/group_analysis.py
+++ b/modules/management/group_analysis/group_analysis.py
@@ -27,7 +27,7 @@ from typing import Optional
 
 from modules.config_utils import load_settings  # noqa: E402
 from modules.analytics import portfolio_summary
-from modules.interface import print_table
+from modules.interface import print_table, print_invalid_choice
 
 SETTINGS = load_settings()
 
@@ -223,7 +223,7 @@ def add_tickers_to_group(groups: pd.DataFrame, group_name: str) -> pd.DataFrame:
     Append to 'groups' DataFrame under the given group_name.
     """
     raw = input(
-        f"Enter ticker symbol(s) to add to group '{group_name}' (comma-separated): "
+        f"Enter ticker symbol(s) to add to group '{group_name}' (comma-separated, or press Enter to cancel): "
     ).strip()
     if not raw:
         print("No tickers entered. Returning to menu.\n")
@@ -293,7 +293,7 @@ def remove_ticker_from_group(groups: pd.DataFrame) -> pd.DataFrame:
         print(f"  {i}) {g}")
     choice = input(f"Select group to modify (1-{len(unique_groups)}): ").strip()
     if not (choice.isdigit() and 1 <= int(choice) <= len(unique_groups)):
-        print("Invalid selection.\n")
+        print_invalid_choice()
         return groups
 
     grp = unique_groups[int(choice) - 1]
@@ -303,7 +303,7 @@ def remove_ticker_from_group(groups: pd.DataFrame) -> pd.DataFrame:
         print(f"  {i}) {t}")
     idx = input(f"Select ticker to remove (1-{len(members)}): ").strip()
     if not (idx.isdigit() and 1 <= int(idx) <= len(members)):
-        print("Invalid selection.\n")
+        print_invalid_choice()
         return groups
 
     to_remove = members[int(idx) - 1]
@@ -327,7 +327,7 @@ def delete_group(groups: pd.DataFrame) -> pd.DataFrame:
         print(f"  {i}) {g}")
     choice = input(f"Select group to delete (1-{len(unique_groups)}): ").strip()
     if not (choice.isdigit() and 1 <= int(choice) <= len(unique_groups)):
-        print("Invalid selection.\n")
+        print_invalid_choice()
         return groups
 
     grp = unique_groups[int(choice) - 1]
@@ -404,7 +404,7 @@ def main():
                     groups = add_tickers_to_group(groups, grp_name)
                     save_groups(groups, GROUPS_FILE)
                 else:
-                    print("Invalid selection.\n")
+                    print_invalid_choice()
 
         elif choice == "4":
             groups = remove_ticker_from_group(groups)
@@ -419,7 +419,7 @@ def main():
             break
 
         else:
-            print("Invalid choice. Please select 1-6.\n")
+            print_invalid_choice()
 
 
 if __name__ == "__main__":

--- a/modules/management/note_manager/note_manager.py
+++ b/modules/management/note_manager/note_manager.py
@@ -3,6 +3,8 @@ import re
 from pathlib import Path
 from typing import List, Optional
 
+from modules.interface import print_invalid_choice
+
 
 def get_notes_dir() -> Path:
     """Return the notes directory, creating it if needed."""
@@ -98,4 +100,4 @@ def run_note_manager() -> None:
         elif choice == "4":
             break
         else:
-            print("Invalid choice.\n")
+            print_invalid_choice()

--- a/modules/management/portfolio_manager/portfolio_manager.py
+++ b/modules/management/portfolio_manager/portfolio_manager.py
@@ -20,7 +20,7 @@ import sys
 from typing import Optional
 
 from modules.analytics import portfolio_summary, sector_counts
-from modules.interface import print_table
+from modules.interface import print_table, print_invalid_choice
 
 import pandas as pd
 import requests
@@ -186,7 +186,7 @@ def add_tickers(portfolio: pd.DataFrame) -> pd.DataFrame:
     - Append a new row to the portfolio DataFrame.
     """
     raw = input(
-        "Enter ticker symbol(s) to add (comma-separated, e.g. AAPL, MSFT): "
+        "Enter ticker symbol(s) to add (comma-separated, or press Enter to cancel): "
     ).strip()
     if not raw:
         print("No tickers entered. Returning to main menu.\n")
@@ -334,7 +334,7 @@ def main():
             break
 
         else:
-            print("Invalid choice. Please select 1-5.\n")
+            print_invalid_choice()
 
 
 if __name__ == "__main__":

--- a/modules/management/settings_manager/settings_manager.py
+++ b/modules/management/settings_manager/settings_manager.py
@@ -6,6 +6,8 @@ import json
 from pathlib import Path
 from typing import Dict
 
+from modules.interface import print_invalid_choice
+
 import importlib
 
 from modules.config_utils import CONFIG_DIR, ENV_PATH, SETTINGS_PATH, load_env, load_settings, save_env, save_settings
@@ -106,7 +108,7 @@ def _general_settings_menu() -> None:
         elif choice == "4":
             break
         else:
-            print("Invalid choice.\n")
+            print_invalid_choice()
 
 
 def _env_menu() -> None:
@@ -126,7 +128,7 @@ def _env_menu() -> None:
         elif choice == "4":
             break
         else:
-            print("Invalid choice.\n")
+            print_invalid_choice()
 
 
 def _wizards_menu() -> None:
@@ -144,7 +146,7 @@ def _wizards_menu() -> None:
         print(f"{len(order)+1}) Return to Settings Menu")
         choice = input(f"Enter 1-{len(order)+1}: ").strip()
         if not choice.isdigit() or not (1 <= int(choice) <= len(order)+1):
-            print("Invalid choice.\n")
+            print_invalid_choice()
             continue
         idx = int(choice)
         if idx == len(order)+1:
@@ -174,7 +176,7 @@ def run_settings_manager() -> None:
             print(f"{idx}) {lbl}")
         choice = input("Enter 1-5: ").strip()
         if not choice.isdigit() or not (1 <= int(choice) <= len(options)):
-            print("Invalid choice.\n")
+            print_invalid_choice()
             continue
         idx = int(choice) - 1
         _, action = options[idx]

--- a/modules/management/settings_manager/wizards/timezone.py
+++ b/modules/management/settings_manager/wizards/timezone.py
@@ -3,6 +3,7 @@
 from zoneinfo import available_timezones
 
 from modules.config_utils import load_settings, save_settings
+from modules.interface import print_invalid_choice
 
 LABEL = "Timezone"
 
@@ -21,7 +22,7 @@ def run_wizard() -> None:
             break
     choice = input(f"Select 1-{min(len(matches),50)}: ").strip()
     if not choice.isdigit() or not (1 <= int(choice) <= min(len(matches),50)):
-        print("Invalid choice.\n")
+        print_invalid_choice()
         return
     tz = matches[int(choice) - 1]
     settings = load_settings()

--- a/scripts/main.py
+++ b/scripts/main.py
@@ -8,6 +8,7 @@ to the various management tools bundled with Fundalyze.
 import sys
 import os
 import argparse
+import textwrap
 
 # Add the repository root to sys.path so 'modules' can be imported when this
 # script is executed directly via `python scripts/main.py`.
@@ -18,6 +19,7 @@ if REPO_ROOT not in sys.path:
 
 # Ensure environment variables from config/.env are loaded before other modules
 from modules.config_utils import load_settings  # noqa: E402
+from modules.interface import print_invalid_choice
 
 from modules.management.portfolio_manager.portfolio_manager import main as run_portfolio_manager
 from modules.management.group_analysis.group_analysis import main as run_group_analysis
@@ -46,7 +48,7 @@ def exit_program():
 
 def invalid_choice():
     """Handle invalid menu selection."""
-    print("Invalid choice. Please select a valid option.\n")
+    print_invalid_choice()
 
 
 def run_portfolio_groups() -> None:
@@ -71,7 +73,7 @@ def run_portfolio_groups() -> None:
         print("8) Remove Ticker from Group")
         print("9) Delete Group")
         print("10) Return to Main Menu")
-        choice = input("Enter 1-10: ").strip()
+        choice = input("Select an option [1-10]: ").strip()
 
         if choice == "1":
             pm.view_portfolio(portfolio)
@@ -114,7 +116,7 @@ def run_portfolio_groups() -> None:
                     groups = ga.add_tickers_to_group(groups, grp_name)
                     ga.save_groups(groups, ga.GROUPS_FILE)
                 else:
-                    print("Invalid selection.\n")
+                    print_invalid_choice()
         elif choice == "8":
             groups = ga.remove_ticker_from_group(groups)
             ga.save_groups(groups, ga.GROUPS_FILE)
@@ -171,7 +173,7 @@ def interactive_menu():
         print("\n📂 Main Menu")
         for idx, (label, _) in enumerate(actions, start=1):
             print(f"{idx}) {label}")
-        choice = input(f"Enter 1-{len(actions)}: ").strip()
+        choice = input(f"Select an option [1-{len(actions)}]: ").strip()
 
         if choice.isdigit():
             idx = int(choice) - 1
@@ -186,11 +188,23 @@ def interactive_menu():
 
 def parse_args() -> argparse.Namespace:
     """Return parsed CLI arguments."""
-    parser = argparse.ArgumentParser(description="Fundalyze command line interface")
+    examples = textwrap.dedent(
+        """
+        Examples:
+          python scripts/main.py portfolio  # open portfolio manager
+          python scripts/main.py report     # generate reports
+        """
+    )
+    parser = argparse.ArgumentParser(
+        description="Fundalyze command line interface",
+        epilog=examples,
+        formatter_class=argparse.RawTextHelpFormatter,
+    )
     sub = parser.add_subparsers(dest="command")
     for cmd in COMMAND_MAP:
         sub.add_parser(cmd, help=COMMAND_HELP.get(cmd, cmd))
     sub.add_parser("menu", help="Interactive menu (default)")
+    parser.add_argument("--version", action="version", version="Fundalyze 1.0")
     return parser.parse_args()
 
 


### PR DESCRIPTION
## Summary
- standardize menu error messages with `print_invalid_choice`
- clarify prompts for entering tickers
- add usage examples and `--version` to CLI argument parser
- tweak menu text for clarity
- document changes in `UI_IMPROVEMENT_REPORT.md`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68411bdcb09883279704a247d46e8c49