### PR TITLE
Refactor report generation utilities

### DIFF
--- a/CORE_ENHANCEMENT_SUMMARY.md
+++ b/CORE_ENHANCEMENT_SUMMARY.md
@@ -1,0 +1,40 @@
+# Core Enhancement Summary
+
+## Modules Updated
+
+- **modules/generate_report/report_generator.py**
+  - Refactored `fetch_and_compile` by splitting profile, price history and financial statement retrieval into helper functions.
+  - Added `_ensure_openbb`, `_fetch_profile`, `_fetch_price_history`, `_fetch_financials`, and `_write_outputs` for modularity.
+  - Utilized new `record_file_metadata` and `iso_timestamp_utc` utilities.
+  - Updated docstring and removed direct `time` usage.
+- **modules/generate_report/utils.py**
+  - Added `record_file_metadata` helper and expanded module docstring.
+- **modules/generate_report/__init__.py**
+  - Added simple progress display when generating multiple reports.
+- **docs/report_generation.md**
+  - Documented progress messages during report generation.
+
+## Example Changes
+
+### Before
+```python
+metadata = {
+    "ticker": symbol,
+    "generated_on": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+    "files": {}
+}
+```
+
+### After
+```python
+metadata = {
+    "ticker": symbol,
+    "generated_on": iso_timestamp_utc(),
+    "files": {}
+}
+```
+
+### New Helper Usage
+```python
+record_file_metadata(metadata, "profile.csv", "OpenBB (equity.profile)", fmp_profile_url)
+```

--- a/docs/report_generation.md
+++ b/docs/report_generation.md
@@ -8,7 +8,7 @@ The report workflow is orchestrated by `run_generate_report()` in `modules.gener
 It performs the following steps:
 
 1. Prompt for ticker symbols.
-2. Call `fetch_and_compile()` for each ticker to download profile data, price history and financial statements.  Data is saved under `output/<TICKER>/`.
+2. Call `fetch_and_compile()` for each ticker to download profile data, price history and financial statements.  Progress is printed for each ticker while data is saved under `output/<TICKER>/`.
 3. Run `metadata_checker` to re-fetch any files that failed during the initial download.
 4. Run `fallback_data` which attempts additional yfinance/FMP downloads if information is still missing.
 5. Build an Excel dashboard using `excel_dashboard.create_and_open_dashboard()` and open it automatically.

--- a/modules/generate_report/__init__.py
+++ b/modules/generate_report/__init__.py
@@ -68,7 +68,9 @@ def run_generate_report():
     if not tickers:
         print("No tickers selected. Returning to main menu.\n")
         return
-    for tk in tickers:
+    total = len(tickers)
+    for idx, tk in enumerate(tickers, start=1):
+        print(f"\n[{idx}/{total}] Generating report for {tk}...")
         try:
             fetch_and_compile(tk)
         except Exception as e:

--- a/modules/generate_report/report_generator.py
+++ b/modules/generate_report/report_generator.py
@@ -10,31 +10,179 @@ Usage:
 
 import os
 import sys
-import time
 import json
 import pandas as pd
 import matplotlib.pyplot as plt
 
 from modules.config_utils import get_output_dir
+from .utils import iso_timestamp_utc, record_file_metadata
 
 # Delay heavy OpenBB import until needed
 obb = None
 
 
-def fetch_and_compile(symbol: str, base_output: str | None = None):
-    """
-    1) Create output/<symbol>/
-    2) Fetch company profile, save as profile.csv, record source & source_url
-    3) Fetch 1mo prices, save 1mo_prices.csv & 1mo_close.png, record sources/URLs
-    4) Fetch income/balance/cash (annual & quarterly), save CSVs, record sources/URLs
-    5) Write report.md with clickable [label](url) for each source
-    6) Write metadata.json containing {"source", "source_url", "fetched_at"} for each file
-    """
+def _ensure_openbb() -> None:
+    """Lazily import :mod:`openbb` when first required."""
     global obb
     if obb is None:
         from openbb import obb as _obb
         obb = _obb
 
+
+def _fetch_profile(symbol: str, ticker_dir: str, report_lines: list, metadata: dict) -> None:
+    """Fetch company profile and update ``report_lines`` and ``metadata``."""
+    _ensure_openbb()
+    profile_path = os.path.join(ticker_dir, "profile.csv")
+    fmp_profile_url = f"https://financialmodelingprep.com/api/v3/profile/{symbol}"
+    try:
+        profile_obj = obb.equity.profile(symbol=symbol)
+        profile_df = profile_obj.to_df()
+        profile_df.to_csv(profile_path, index=False)
+        report_lines.append("- → Saved full profile to `profile.csv`\n\n")
+        report_lines.append(
+            f"**Source:** OpenBB (`equity.profile`) — [FMP Company Profile]({fmp_profile_url})\n\n"
+        )
+        record_file_metadata(metadata, "profile.csv", "OpenBB (equity.profile)", fmp_profile_url)
+    except Exception as e:
+        report_lines.append(f"> Error fetching profile for {symbol}: {e}\n\n")
+        report_lines.append("**Source:** ERROR occurred; see metadata.json\n\n")
+        cols = [
+            "symbol",
+            "price",
+            "beta",
+            "volAvg",
+            "mktCap",
+            "lastDiv",
+            "range",
+            "changes",
+            "exchange",
+            "industry",
+            "website",
+            "description",
+            "ceo",
+            "sector",
+            "country",
+            "fullTimeEmployees",
+            "phone",
+            "address",
+            "city",
+            "state",
+            "zip",
+            "dcfDiff",
+            "dcf",
+            "image",
+        ]
+        pd.DataFrame(columns=cols).to_csv(profile_path, index=False)
+        record_file_metadata(metadata, "profile.csv", f"ERROR: {e}", fmp_profile_url)
+
+
+def _fetch_price_history(symbol: str, ticker_dir: str, report_lines: list, metadata: dict) -> None:
+    """Fetch 1‑month price history and chart."""
+    _ensure_openbb()
+    price_csv_path = os.path.join(ticker_dir, "1mo_prices.csv")
+    price_chart_path = os.path.join(ticker_dir, "1mo_close.png")
+    yahoo_hist_url = f"https://finance.yahoo.com/quote/{symbol}/history?p={symbol}"
+    try:
+        hist_obj = obb.equity.price.historical(symbol=symbol, period="1mo", provider="yfinance")
+        hist_df = hist_obj.to_df()
+        for col in ("Dividends", "Stock Splits"):
+            if col in hist_df.columns:
+                hist_df = hist_df.drop(columns=[col])
+        hist_df.to_csv(price_csv_path, index=False)
+        report_lines.append("- → Saved 1 month price history to `1mo_prices.csv`\n\n")
+        report_lines.append(
+            f"**Source:** OpenBB (`equity.price.historical`, provider=`yfinance`) — [Yahoo Finance History]({yahoo_hist_url})\n\n"
+        )
+        plt.figure(figsize=(8, 4))
+        hist_df["Close"].plot(title=f"{symbol} Close Price (Last 1 Month)")
+        plt.xlabel("Date")
+        plt.ylabel("Close Price (USD)")
+        plt.tight_layout()
+        plt.savefig(price_chart_path, dpi=150)
+        plt.close()
+        report_lines.append("- → Saved price chart to `1mo_close.png`\n\n")
+        record_file_metadata(metadata, "1mo_close.png", "Visualization (matplotlib)")
+        report_lines.append("Last 5 rows:\n\n")
+        report_lines.append(hist_df.tail(5).to_markdown(tablefmt="github"))
+        report_lines.append("\n\n")
+        record_file_metadata(metadata, "1mo_prices.csv", "OpenBB (equity.price.historical, yfinance)", yahoo_hist_url)
+    except Exception as e:
+        report_lines.append(f"> Error fetching 1-month price history for {symbol}: {e}\n\n")
+        report_lines.append("**Source:** ERROR occurred; see metadata.json\n\n")
+        placeholder_cols = ["Date", "Open", "High", "Low", "Close", "Adj Close", "Volume"]
+        pd.DataFrame(columns=placeholder_cols).to_csv(price_csv_path, index=False)
+        record_file_metadata(metadata, "1mo_prices.csv", f"ERROR: {e}", yahoo_hist_url)
+
+
+def _fetch_financials(symbol: str, ticker_dir: str, report_lines: list, metadata: dict) -> None:
+    """Fetch financial statements via OpenBB."""
+    _ensure_openbb()
+    report_lines.append("## 3) Financial Statements\n")
+    statements = [
+        ("income", "Annual Income Statement", "annual", "income_annual.csv", f"https://finance.yahoo.com/quote/{symbol}/financials"),
+        ("income", "Quarterly Income Statement", "quarter", "income_quarter.csv", f"https://finance.yahoo.com/quote/{symbol}/financials"),
+        ("balance", "Annual Balance Sheet", "annual", "balance_annual.csv", f"https://finance.yahoo.com/quote/{symbol}/balance-sheet"),
+        ("balance", "Quarterly Balance Sheet", "quarter", "balance_quarter.csv", f"https://finance.yahoo.com/quote/{symbol}/balance-sheet"),
+        ("cash", "Annual Cash Flow", "annual", "cash_annual.csv", f"https://finance.yahoo.com/quote/{symbol}/cash-flow"),
+        ("cash", "Quarterly Cash Flow", "quarter", "cash_quarter.csv", f"https://finance.yahoo.com/quote/{symbol}/cash-flow"),
+    ]
+    for stmt, label, period, filename, source_url in statements:
+        report_lines.append(f"### {label} ({period.title()})\n")
+        fin_path = os.path.join(ticker_dir, filename)
+        try:
+            fn = getattr(obb.equity.fundamental, stmt)
+            fin_obj = fn(symbol=symbol, period=period)
+            fin_df = fin_obj.to_df()
+            if isinstance(fin_df, pd.DataFrame) and not fin_df.empty:
+                fin_df.to_csv(fin_path, index=True)
+                report_lines.append(f"- → Saved to `{filename}`\n\n")
+                report_lines.append(
+                    f"**Source:** OpenBB (`equity.fundamental.{stmt}`, {period}) — [Yahoo Finance]({source_url})\n\n"
+                )
+                report_lines.append("First 3 rows:\n\n")
+                report_lines.append(fin_df.head(3).to_markdown(tablefmt="github"))
+                report_lines.append("\n\n")
+                record_file_metadata(metadata, filename, f"OpenBB (equity.fundamental.{stmt}, {period})", source_url)
+            else:
+                report_lines.append(f"> {label} not available or empty for {symbol}.\n\n")
+                pd.DataFrame().to_csv(fin_path)
+                record_file_metadata(metadata, filename, "Empty DataFrame (no data returned)", source_url)
+        except Exception as e:
+            report_lines.append(f"> {label} error for {symbol}: {e}\n\n")
+            report_lines.append("**Source:** ERROR occurred; see metadata.json\n\n")
+            pd.DataFrame().to_csv(fin_path)
+            record_file_metadata(metadata, filename, f"ERROR: {e}", source_url)
+
+
+def _write_outputs(ticker_dir: str, report_lines: list, metadata: dict) -> None:
+    """Write ``report.md`` and ``metadata.json`` into ``ticker_dir``."""
+    report_path = os.path.join(ticker_dir, "report.md")
+    with open(report_path, "w", encoding="utf-8") as f:
+        f.write("\n".join(report_lines))
+    record_file_metadata(metadata, "report.md", "Aggregated Markdown report (multiple sources)")
+    meta_path = os.path.join(ticker_dir, "metadata.json")
+    with open(meta_path, "w", encoding="utf-8") as f:
+        json.dump(metadata, f, indent=2)
+    print(f"✅ Completed report for {os.path.basename(ticker_dir)}: {report_path}")
+
+
+def fetch_and_compile(symbol: str, base_output: str | None = None):
+    """Generate all report files for ``symbol`` under ``output/``.
+
+    Steps performed:
+        1. Create ``output/<symbol>/`` if needed.
+        2. Fetch company profile.
+        3. Fetch 1‑month price history and chart.
+        4. Fetch annual/quarterly financial statements.
+        5. Write ``report.md`` and ``metadata.json`` summarizing sources.
+
+    Parameters
+    ----------
+    symbol:
+        Stock ticker symbol.
+    base_output:
+        Optional root directory; defaults to :func:`modules.config_utils.get_output_dir`.
+    """
     if base_output is None:
         base_output = str(get_output_dir())
 
@@ -45,7 +193,7 @@ def fetch_and_compile(symbol: str, base_output: str | None = None):
     # Initialize metadata
     metadata = {
         "ticker": symbol,
-        "generated_on": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+        "generated_on": iso_timestamp_utc(),
         "files": {}
     }
 
@@ -53,194 +201,15 @@ def fetch_and_compile(symbol: str, base_output: str | None = None):
     report_lines.append(f"# Report for {symbol}\n")
     report_lines.append(f"*Generated via OpenBB Platform*\n\n")
 
-    #
-    # 1) Company Profile
-    #
     report_lines.append("## 1) Company Profile\n")
+    _fetch_profile(symbol, ticker_dir, report_lines, metadata)
 
-    # Define profile_path before try/except
-    profile_path = os.path.join(ticker_dir, "profile.csv")
-    fmp_profile_url = f"https://financialmodelingprep.com/api/v3/profile/{symbol}"
-
-    try:
-        profile_obj = obb.equity.profile(symbol=symbol)
-        profile_df = profile_obj.to_df()
-        profile_df.to_csv(profile_path, index=False)
-
-        report_lines.append(f"- → Saved full profile to `profile.csv`\n\n")
-        report_lines.append(f"**Source:** OpenBB (`equity.profile`) — [FMP Company Profile]({fmp_profile_url})\n\n")
-
-        metadata["files"]["profile.csv"] = {
-            "source": "OpenBB (equity.profile)",
-            "source_url": fmp_profile_url,
-            "fetched_at": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())
-        }
-
-    except Exception as e:
-        report_lines.append(f"> Error fetching profile for {symbol}: {e}\n\n")
-        report_lines.append("**Source:** ERROR occurred; see metadata.json\n\n")
-
-        # Write an empty placeholder with expected columns
-        cols = [
-            "symbol", "price", "beta", "volAvg", "mktCap", "lastDiv", "range", "changes",
-            "exchange", "industry", "website", "description", "ceo", "sector", "country",
-            "fullTimeEmployees", "phone", "address", "city", "state", "zip", "dcfDiff",
-            "dcf", "image"
-        ]
-        pd.DataFrame(columns=cols).to_csv(profile_path, index=False)
-
-        metadata["files"]["profile.csv"] = {
-            "source": f"ERROR: {e}",
-            "source_url": fmp_profile_url,
-            "fetched_at": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())
-        }
-
-    #
-    # 2) Price History (Last 1 Month)
-    #
     report_lines.append("## 2) Price History (Last 1 Month)\n")
+    _fetch_price_history(symbol, ticker_dir, report_lines, metadata)
 
-    # Define paths and URL before try/except
-    price_csv_path = os.path.join(ticker_dir, "1mo_prices.csv")
-    price_chart_path = os.path.join(ticker_dir, "1mo_close.png")
-    yahoo_hist_url = f"https://finance.yahoo.com/quote/{symbol}/history?p={symbol}"
+    _fetch_financials(symbol, ticker_dir, report_lines, metadata)
 
-    try:
-        hist_obj = obb.equity.price.historical(
-            symbol=symbol, period="1mo", provider="yfinance"
-        )
-        hist_df = hist_obj.to_df()
-        for col in ("Dividends", "Stock Splits"):
-            if col in hist_df.columns:
-                hist_df = hist_df.drop(columns=[col])
-
-        hist_df.to_csv(price_csv_path, index=False)
-        report_lines.append(f"- → Saved 1 month price history to `1mo_prices.csv`\n\n")
-        report_lines.append(f"**Source:** OpenBB (`equity.price.historical`, provider=`yfinance`) — [Yahoo Finance History]({yahoo_hist_url})\n\n")
-
-        # Plot closing price
-        plt.figure(figsize=(8, 4))
-        hist_df["Close"].plot(title=f"{symbol} Close Price (Last 1 Month)")
-        plt.xlabel("Date")
-        plt.ylabel("Close Price (USD)")
-        plt.tight_layout()
-        plt.savefig(price_chart_path, dpi=150)
-        plt.close()
-
-        report_lines.append(f"- → Saved price chart to `1mo_close.png`\n\n")
-        metadata["files"]["1mo_close.png"] = {
-            "source": "Visualization (matplotlib)",
-            "source_url": "",
-            "fetched_at": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())
-        }
-
-        report_lines.append("Last 5 rows:\n\n")
-        report_lines.append(hist_df.tail(5).to_markdown(tablefmt="github"))
-        report_lines.append("\n\n")
-
-        metadata["files"]["1mo_prices.csv"] = {
-            "source": "OpenBB (equity.price.historical, yfinance)",
-            "source_url": yahoo_hist_url,
-            "fetched_at": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())
-        }
-
-    except Exception as e:
-        report_lines.append(f"> Error fetching 1-month price history for {symbol}: {e}\n\n")
-        report_lines.append("**Source:** ERROR occurred; see metadata.json\n\n")
-
-        # Write placeholder CSV with standard columns
-        placeholder_cols = ["Date", "Open", "High", "Low", "Close", "Adj Close", "Volume"]
-        pd.DataFrame(columns=placeholder_cols).to_csv(price_csv_path, index=False)
-
-        metadata["files"]["1mo_prices.csv"] = {
-            "source": f"ERROR: {e}",
-            "source_url": yahoo_hist_url,
-            "fetched_at": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())
-        }
-
-    #
-    # 3) Financial Statements (Annual + Quarterly for Income, Balance, Cash)
-    #
-    report_lines.append("## 3) Financial Statements\n")
-
-    statements = [
-        ("income", "Annual Income Statement", "annual", "income_annual.csv", f"https://finance.yahoo.com/quote/{symbol}/financials"),
-        ("income", "Quarterly Income Statement", "quarter", "income_quarter.csv", f"https://finance.yahoo.com/quote/{symbol}/financials"),
-        ("balance", "Annual Balance Sheet", "annual", "balance_annual.csv", f"https://finance.yahoo.com/quote/{symbol}/balance-sheet"),
-        ("balance", "Quarterly Balance Sheet", "quarter", "balance_quarter.csv", f"https://finance.yahoo.com/quote/{symbol}/balance-sheet"),
-        ("cash", "Annual Cash Flow", "annual", "cash_annual.csv", f"https://finance.yahoo.com/quote/{symbol}/cash-flow"),
-        ("cash", "Quarterly Cash Flow", "quarter", "cash_quarter.csv", f"https://finance.yahoo.com/quote/{symbol}/cash-flow"),
-    ]
-
-    for stmt, label, period, filename, source_url in statements:
-        report_lines.append(f"### {label} ({period.title()})\n")
-
-        # Define CSV path outside of try/except
-        fin_path = os.path.join(ticker_dir, filename)
-
-        try:
-            fn = getattr(obb.equity.fundamental, stmt)
-            fin_obj = fn(symbol=symbol, period=period)
-            fin_df = fin_obj.to_df()
-
-            if isinstance(fin_df, pd.DataFrame) and not fin_df.empty:
-                fin_df.to_csv(fin_path, index=True)
-                report_lines.append(f"- → Saved to `{filename}`\n\n")
-                report_lines.append(f"**Source:** OpenBB (`equity.fundamental.{stmt}`, {period}) — [Yahoo Finance]({source_url})\n\n")
-                report_lines.append("First 3 rows:\n\n")
-                report_lines.append(fin_df.head(3).to_markdown(tablefmt="github"))
-                report_lines.append("\n\n")
-
-                metadata["files"][filename] = {
-                    "source": f"OpenBB (equity.fundamental.{stmt}, {period})",
-                    "source_url": source_url,
-                    "fetched_at": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())
-                }
-
-            else:
-                report_lines.append(f"> {label} not available or empty for {symbol}.\n\n")
-                metadata["files"][filename] = {
-                    "source": "Empty DataFrame (no data returned)",
-                    "source_url": source_url,
-                    "fetched_at": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())
-                }
-
-                # Write an empty placeholder so downstream code sees a valid file
-                pd.DataFrame().to_csv(fin_path)
-
-        except Exception as e:
-            report_lines.append(f"> {label} error for {symbol}: {e}\n\n")
-            report_lines.append("**Source:** ERROR occurred; see metadata.json\n\n")
-
-            # Write an empty placeholder
-            pd.DataFrame().to_csv(fin_path)
-
-            metadata["files"][filename] = {
-                "source": f"ERROR: {e}",
-                "source_url": source_url,
-                "fetched_at": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())
-            }
-
-    #
-    # 4) Write the aggregated Markdown report
-    #
-    report_path = os.path.join(ticker_dir, "report.md")
-    with open(report_path, "w", encoding="utf-8") as f:
-        f.write("\n".join(report_lines))
-
-    metadata["files"]["report.md"] = {
-        "source": "Aggregated Markdown report (multiple sources)",
-        "source_url": "",
-        "created_at": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())
-    }
-
-    #
-    # 5) Dump metadata.json
-    #
-    with open(os.path.join(ticker_dir, "metadata.json"), "w", encoding="utf-8") as f:
-        json.dump(metadata, f, indent=2)
-
-    print(f"✅ Completed report for {symbol}: {report_path}")
+    _write_outputs(ticker_dir, report_lines, metadata)
 
 
 if __name__ == "__main__":

--- a/modules/generate_report/utils.py
+++ b/modules/generate_report/utils.py
@@ -1,9 +1,35 @@
 from __future__ import annotations
 
+"""Utility helpers used across the :mod:`generate_report` package."""
+
 import time
+from typing import Dict
 
 
 def iso_timestamp_utc() -> str:
-    """Return current UTC timestamp in ISO 8601 format."""
+    """Return the current UTC timestamp in ISO 8601 format."""
     return time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())
+
+
+def record_file_metadata(metadata: Dict, filename: str, source: str, source_url: str = "") -> None:
+    """Update ``metadata`` dict with file information.
+
+    Parameters
+    ----------
+    metadata:
+        The metadata dictionary with a ``files`` key.
+    filename:
+        Name of the file being recorded.
+    source:
+        Human readable description of the data source.
+    source_url:
+        Optional URL where the data was retrieved from.
+    """
+
+    files = metadata.setdefault("files", {})
+    files[filename] = {
+        "source": source,
+        "source_url": source_url,
+        "fetched_at": iso_timestamp_utc(),
+    }
 


### PR DESCRIPTION
## Summary
- break `fetch_and_compile` into smaller helpers
- add `record_file_metadata` helper
- show progress while generating reports
- document progress in reporting docs

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68411bd7a3d48327949124693ea6af30