### PR TITLE
Refine CLI prompts and help text

### DIFF
--- a/UI_IMPROVEMENT_REPORT.md
+++ b/UI_IMPROVEMENT_REPORT.md
@@ -27,3 +27,12 @@ The Fundalyze project uses a command line interface exposed via `scripts/main.py
 - `modules/generate_report/__init__.py`
 
 These changes ensure consistent feedback across the CLI and provide clearer guidance for new users.
+
+### Additional Updates
+
+- Refined `INVALID_CHOICE_MSG` in `modules/interface.py` to instruct users to
+  press `Ctrl+C` for exit.
+- Standardised all menu prompts to use the `Select an option [n]` pattern for
+  clarity.
+- Added subcommand descriptions in `scripts/main.py` so `--help` shows a brief
+  explanation for each command.

--- a/modules/generate_report/__init__.py
+++ b/modules/generate_report/__init__.py
@@ -23,7 +23,7 @@ def _select_tickers() -> list[str]:
     print("2) Use all tickers from portfolio")
     print("3) Choose a group")
     print("4) Return to Main Menu")
-    choice = input("Enter 1-4: ").strip()
+    choice = input("Select an option [1-4]: ").strip()
 
     if choice == "1":
         raw = input("Enter ticker symbol(s), comma-separated): ").strip()

--- a/modules/interface.py
+++ b/modules/interface.py
@@ -3,7 +3,9 @@ from __future__ import annotations
 import pandas as pd
 from tabulate import tabulate
 
-INVALID_CHOICE_MSG = "Invalid choice. Please select a valid option.\n"
+INVALID_CHOICE_MSG = (
+    "Invalid choice. Enter a number from the menu or press Ctrl+C to exit.\n"
+)
 
 
 def print_table(df: pd.DataFrame, *, showindex: bool = False) -> None:

--- a/modules/management/directus_tools/directus_wizard.py
+++ b/modules/management/directus_tools/directus_wizard.py
@@ -31,7 +31,7 @@ def run_directus_wizard() -> None:
         print("4) Fetch Items from Collection")
         print("5) Insert Item into Collection")
         print("6) Return to Main Menu")
-        choice = input("Enter 1-6: ").strip()
+        choice = input("Select an option [1-6]: ").strip()
 
         if choice == "1":
             cols = dc.list_collections()

--- a/modules/management/group_analysis/group_analysis.py
+++ b/modules/management/group_analysis/group_analysis.py
@@ -366,7 +366,7 @@ def main():
         print("  4) Remove ticker from a group")
         print("  5) Delete an entire group")
         print("  6) Exit")
-        choice = input("Enter 1/2/3/4/5/6: ").strip()
+        choice = input("Select an option [1-6]: ").strip()
 
         if choice == "1":
             view_groups(groups)

--- a/modules/management/note_manager/note_manager.py
+++ b/modules/management/note_manager/note_manager.py
@@ -65,7 +65,7 @@ def run_note_manager() -> None:
         print("2) View Note")
         print("3) Create Note")
         print("4) Return to Main Menu")
-        choice = input("Enter 1-4: ").strip()
+        choice = input("Select an option [1-4]: ").strip()
 
         if choice == "1":
             notes = list_notes()

--- a/modules/management/portfolio_manager/portfolio_manager.py
+++ b/modules/management/portfolio_manager/portfolio_manager.py
@@ -310,7 +310,7 @@ def main():
         print("  3) Update ticker data")
         print("  4) Remove ticker")
         print("  5) Exit")
-        choice = input("Enter 1/2/3/4/5: ").strip()
+        choice = input("Select an option [1-5]: ").strip()
 
         if choice == "1":
             view_portfolio(portfolio)

--- a/modules/management/settings_manager/settings_manager.py
+++ b/modules/management/settings_manager/settings_manager.py
@@ -97,7 +97,7 @@ def _general_settings_menu() -> None:
         print("2) Set Setting")
         print("3) Delete Setting")
         print("4) Return to Settings Menu")
-        choice = input("Enter 1-4: ").strip()
+        choice = input("Select an option [1-4]: ").strip()
         if choice == "1":
             _show_dict(load_settings())
         elif choice == "2":
@@ -117,7 +117,7 @@ def _env_menu() -> None:
         print("2) Set .env Variable")
         print("3) Delete .env Variable")
         print("4) Return to Settings Menu")
-        choice = input("Enter 1-4: ").strip()
+        choice = input("Select an option [1-4]: ").strip()
         if choice == "1":
             _show_dict(load_env())
         elif choice == "2":
@@ -149,7 +149,7 @@ def _wizards_menu() -> None:
         for idx, lbl in enumerate(order, start=1):
             print(f"{idx}) Setup {lbl}")
         print(f"{len(order)+1}) Return to Settings Menu")
-        choice = input(f"Enter 1-{len(order)+1}: ").strip()
+        choice = input(f"Select an option [1-{len(order)+1}]: ").strip()
         if not choice.isdigit() or not (1 <= int(choice) <= len(order)+1):
             print_invalid_choice()
             continue
@@ -179,7 +179,7 @@ def run_settings_manager() -> None:
         ]
         for idx, (lbl, _) in enumerate(options, start=1):
             print(f"{idx}) {lbl}")
-        choice = input("Enter 1-5: ").strip()
+        choice = input("Select an option [1-5]: ").strip()
         if not choice.isdigit() or not (1 <= int(choice) <= len(options)):
             print_invalid_choice()
             continue

--- a/scripts/main.py
+++ b/scripts/main.py
@@ -202,7 +202,11 @@ def parse_args() -> argparse.Namespace:
     )
     sub = parser.add_subparsers(dest="command")
     for cmd in COMMAND_MAP:
-        sub.add_parser(cmd, help=COMMAND_HELP.get(cmd, cmd))
+        sub.add_parser(
+            cmd,
+            help=COMMAND_HELP.get(cmd, cmd),
+            description=COMMAND_HELP.get(cmd, cmd),
+        )
     sub.add_parser("menu", help="Interactive menu (default)")
     parser.add_argument("--version", action="version", version="Fundalyze 1.0")
     return parser.parse_args()


### PR DESCRIPTION
## Summary
- tweak invalid menu message for clarity
- unify menu prompts across tools
- add descriptions for CLI subcommands
- update UI_IMPROVEMENT_REPORT

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841206b69e4832794c96d1396363d40