### PR TITLE
Add tests for group analysis input handling

### DIFF
--- a/BUG_AUDIT_REPORT.md
+++ b/BUG_AUDIT_REPORT.md
@@ -14,6 +14,7 @@
 - **tests/test_directus_client.py & test_excel_dashboard_extra.py** – removed unused imports.
 - **modules/generate_report/__init__.py** – removed unused `run_metadata_checker` import.
 - **tests/test_data_utils_edge.py** – added edge case tests for data utilities.
+- **tests/test_group_analysis.py** – added input-handling tests for ticker confirmation and group selection.
 
 ## Remaining Warnings
 - `modules/management/directus_tools/__init__.py` re-exports a function causing an unused import warning. This is intentional and can be ignored.

--- a/tests/test_group_analysis.py
+++ b/tests/test_group_analysis.py
@@ -20,3 +20,42 @@ def test_save_groups_directus(monkeypatch):
     ga.save_groups(df, "dummy.xlsx")
     assert captured["rec"] == [{"Group": "G", "Ticker": "AAA", "Name": "Alpha"}]
 
+
+def test_confirm_or_adjust_ticker_yes(monkeypatch):
+    inputs = iter(["y"])
+    monkeypatch.setattr("builtins.input", lambda *_: next(inputs))
+    assert ga.confirm_or_adjust_ticker("AAA") == "AAA"
+
+
+def test_confirm_or_adjust_ticker_no_change(monkeypatch):
+    inputs = iter(["n", "BBB"])
+    monkeypatch.setattr("builtins.input", lambda *_: next(inputs))
+    assert ga.confirm_or_adjust_ticker("AAA") == "BBB"
+
+
+def test_confirm_or_adjust_ticker_cancel(monkeypatch):
+    inputs = iter(["maybe", "n", ""])
+    monkeypatch.setattr("builtins.input", lambda *_: next(inputs))
+    assert ga.confirm_or_adjust_ticker("AAA") == ""
+
+
+def test_choose_group_with_portfolio(monkeypatch):
+    df = pd.DataFrame({"Ticker": ["AAA", "BBB"]})
+    inputs = iter(["1"])
+    monkeypatch.setattr("builtins.input", lambda *_: next(inputs))
+    assert ga.choose_group(df) == "AAA"
+
+
+def test_choose_group_custom(monkeypatch):
+    df = pd.DataFrame({"Ticker": ["AAA"]})
+    inputs = iter(["2", "MyGrp"])
+    monkeypatch.setattr("builtins.input", lambda *_: next(inputs))
+    assert ga.choose_group(df) == "MyGrp"
+
+
+def test_choose_group_empty(monkeypatch):
+    df = pd.DataFrame()
+    inputs = iter(["GroupX"])
+    monkeypatch.setattr("builtins.input", lambda *_: next(inputs))
+    assert ga.choose_group(df) == "GroupX"
+


### PR DESCRIPTION
## Summary
- test confirm_or_adjust_ticker user flow with yes/no/cancel
- test choose_group path for portfolio and custom groups
- record the new tests in `BUG_AUDIT_REPORT.md`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684123933610832783a06f382ee6a11b