### PR TITLE
Improve CLI headings and prompts

### DIFF
--- a/UI_IMPROVEMENT_REPORT.md
+++ b/UI_IMPROVEMENT_REPORT.md
@@ -36,3 +36,13 @@ These changes ensure consistent feedback across the CLI and provide clearer guid
   clarity.
 - Added subcommand descriptions in `scripts/main.py` so `--help` shows a brief
   explanation for each command.
+
+### Latest Updates
+
+- Added `print_header` helper in `modules/interface.py` for consistent section
+  headings and expanded `INVALID_CHOICE_MSG` to mention running the help flag.
+- Updated menu headers in `scripts/main.py`, `group_analysis.py`, `note_manager.py`
+  and report generation to use `print_header`.
+- Fixed prompt wording in `modules/generate_report/__init__.py` and standardized
+  group-selection messages to the `[1-n]` format.
+- Improved note creation flow to allow cancellation with Enter or 'q'.

--- a/modules/generate_report/__init__.py
+++ b/modules/generate_report/__init__.py
@@ -13,12 +13,12 @@ from modules.management.group_analysis.group_analysis import (
     load_groups,
     GROUPS_FILE,
 )
-from modules.interface import print_invalid_choice
+from modules.interface import print_invalid_choice, print_header
 
 
 def _select_tickers() -> list[str]:
     """Prompt user to choose tickers manually, from portfolio or a group."""
-    print("\n📑 Reports")
+    print_header("📑 Reports")
     print("1) Enter ticker symbols manually")
     print("2) Use all tickers from portfolio")
     print("3) Choose a group")
@@ -26,7 +26,9 @@ def _select_tickers() -> list[str]:
     choice = input("Select an option [1-4]: ").strip()
 
     if choice == "1":
-        raw = input("Enter ticker symbol(s), comma-separated): ").strip()
+        raw = input(
+            "Enter ticker symbol(s), comma-separated (or press Enter to cancel): "
+        ).strip()
         return [t.strip().upper() for t in raw.split(",") if t.strip()]
 
     if choice == "2":
@@ -41,7 +43,7 @@ def _select_tickers() -> list[str]:
             return []
         for i, g in enumerate(names, start=1):
             print(f"  {i}) {g}")
-        sel = input(f"Select group 1-{len(names)}: ").strip()
+        sel = input(f"Select a group [1-{len(names)}]: ").strip()
         if sel.isdigit() and 1 <= int(sel) <= len(names):
             grp = names[int(sel) - 1]
             df = groups[groups["Group"] == grp]
@@ -63,7 +65,7 @@ def run_generate_report():
     4) run fallback data.
     5) build and open an Excel dashboard.
     """
-    print("\n📑 Reports")
+    print_header("📑 Reports")
     print("Generate reports (metadata, fallback & Excel export).")
     tickers = _select_tickers()
     if not tickers:

--- a/modules/interface.py
+++ b/modules/interface.py
@@ -4,8 +4,14 @@ import pandas as pd
 from tabulate import tabulate
 
 INVALID_CHOICE_MSG = (
-    "Invalid choice. Enter a number from the menu or press Ctrl+C to exit.\n"
+    "Invalid choice. Enter a number from the menu or press Ctrl+C to exit. "
+    "Run 'python scripts/main.py --help' for usage.\n"
 )
+
+
+def print_header(title: str) -> None:
+    """Display a section heading consistently across menus."""
+    print(f"\n=== {title} ===")
 
 
 def print_table(df: pd.DataFrame, *, showindex: bool = False) -> None:

--- a/modules/management/group_analysis/group_analysis.py
+++ b/modules/management/group_analysis/group_analysis.py
@@ -25,7 +25,7 @@ import os
 
 from modules.config_utils import load_settings  # noqa: E402
 from modules.analytics import portfolio_summary
-from modules.interface import print_table, print_invalid_choice
+from modules.interface import print_table, print_invalid_choice, print_header
 
 SETTINGS = load_settings()
 
@@ -289,7 +289,7 @@ def remove_ticker_from_group(groups: pd.DataFrame) -> pd.DataFrame:
     unique_groups = groups["Group"].dropna().unique().tolist()
     for i, g in enumerate(unique_groups, start=1):
         print(f"  {i}) {g}")
-    choice = input(f"Select group to modify (1-{len(unique_groups)}): ").strip()
+    choice = input(f"Select a group to modify [1-{len(unique_groups)}]: ").strip()
     if not (choice.isdigit() and 1 <= int(choice) <= len(unique_groups)):
         print_invalid_choice()
         return groups
@@ -323,7 +323,7 @@ def delete_group(groups: pd.DataFrame) -> pd.DataFrame:
     unique_groups = groups["Group"].dropna().unique().tolist()
     for i, g in enumerate(unique_groups, start=1):
         print(f"  {i}) {g}")
-    choice = input(f"Select group to delete (1-{len(unique_groups)}): ").strip()
+    choice = input(f"Select a group to delete [1-{len(unique_groups)}]: ").strip()
     if not (choice.isdigit() and 1 <= int(choice) <= len(unique_groups)):
         print_invalid_choice()
         return groups
@@ -354,7 +354,7 @@ def view_groups(groups: pd.DataFrame):
 
 
 def main():
-    print("\n=== Group Analysis Manager ===\n")
+    print_header("Group Analysis Manager")
     portfolio = load_portfolio(PORTFOLIO_FILE)
     groups = load_groups(GROUPS_FILE)
 
@@ -396,7 +396,7 @@ def main():
                 unique_groups = groups["Group"].dropna().unique().tolist()
                 for i, g in enumerate(unique_groups, start=1):
                     print(f"  {i}) {g}")
-                sel = input(f"Select group (1-{len(unique_groups)}): ").strip()
+                sel = input(f"Select a group [1-{len(unique_groups)}]: ").strip()
                 if sel.isdigit() and 1 <= int(sel) <= len(unique_groups):
                     grp_name = unique_groups[int(sel) - 1]
                     groups = add_tickers_to_group(groups, grp_name)

--- a/modules/management/note_manager/note_manager.py
+++ b/modules/management/note_manager/note_manager.py
@@ -3,7 +3,7 @@ import re
 from pathlib import Path
 from typing import List, Optional
 
-from modules.interface import print_invalid_choice
+from modules.interface import print_invalid_choice, print_header
 
 
 def get_notes_dir() -> Path:
@@ -60,7 +60,7 @@ def parse_links(content: str) -> List[str]:
 def run_note_manager() -> None:
     """Interactive menu for creating and viewing notes."""
     while True:
-        print("\n📝 Notes")
+        print_header("📝 Notes")
         print("1) List Notes")
         print("2) View Note")
         print("3) Create Note")
@@ -87,11 +87,17 @@ def run_note_manager() -> None:
                     for link in links:
                         print(f"- {link}")
         elif choice == "3":
-            title = input("New note title: ").strip()
-            print("Enter note content. End with an empty line.")
+            title = input("New note title (or press Enter to cancel): ").strip()
+            if not title:
+                print("Canceled.\n")
+                continue
+            print("Enter note content. Finish with an empty line or 'q' to cancel.")
             lines: list[str] = []
             while True:
                 line = input()
+                if line.lower() == "q":
+                    print("Canceled.\n")
+                    return
                 if line == "":
                     break
                 lines.append(line)

--- a/scripts/main.py
+++ b/scripts/main.py
@@ -19,7 +19,7 @@ if REPO_ROOT not in sys.path:
 
 # Ensure environment variables from config/.env are loaded before other modules
 from modules.config_utils import load_settings  # noqa: E402
-from modules.interface import print_invalid_choice
+from modules.interface import print_invalid_choice, print_header
 
 from modules.management.portfolio_manager.portfolio_manager import main as run_portfolio_manager
 from modules.management.group_analysis.group_analysis import main as run_group_analysis
@@ -60,7 +60,7 @@ def run_portfolio_groups() -> None:
     groups = ga.load_groups(ga.GROUPS_FILE)
 
     while True:
-        print("\n🔁 Portfolio & Groups")
+        print_header("🔁 Portfolio & Groups")
         print("--- Portfolio ---")
         print("1) View Portfolio")
         print("2) Add Ticker(s)")
@@ -170,7 +170,7 @@ def interactive_menu():
     actions = ACTION_ITEMS
 
     while True:
-        print("\n📂 Main Menu")
+        print_header("📂 Main Menu")
         for idx, (label, _) in enumerate(actions, start=1):
             print(f"{idx}) {label}")
         choice = input(f"Select an option [1-{len(actions)}]: ").strip()


### PR DESCRIPTION
## Summary
- add `print_header` utility and expanded invalid choice text
- refine report menu prompts
- allow cancelling note creation
- standardize group manager prompts
- add headers in main menu
- document latest usability tweaks

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841239cb1ec8327b121ff40db5a8db6