### PR TITLE
Fix CLI alias and clarify group prompts

### DIFF
--- a/UI_IMPROVEMENT_REPORT.md
+++ b/UI_IMPROVEMENT_REPORT.md
@@ -46,3 +46,12 @@ These changes ensure consistent feedback across the CLI and provide clearer guid
 - Fixed prompt wording in `modules/generate_report/__init__.py` and standardized
   group-selection messages to the `[1-n]` format.
 - Improved note creation flow to allow cancellation with Enter or 'q'.
+
+### Recent Updates
+
+- Fixed CLI crash when running `scripts/main.py` due to missing
+  `run_metadata_checker` export. Added a backwards compatible alias in
+  `modules/generate_report/__init__.py` at line 8.
+- Clarified group creation prompts in
+  `modules/management/group_analysis/group_analysis.py` lines
+  205–219 to mention pressing Enter to cancel selections.

--- a/modules/generate_report/__init__.py
+++ b/modules/generate_report/__init__.py
@@ -5,6 +5,9 @@ from .metadata_checker import run_for_tickers
 from .fallback_data import run_fallback_data
 from .excel_dashboard import create_and_open_dashboard
 
+# Backwards compatible alias used by `scripts/main.py`
+run_metadata_checker = run_for_tickers
+
 from modules.management.portfolio_manager.portfolio_manager import (
     load_portfolio,
     PORTFOLIO_FILE,

--- a/modules/management/group_analysis/group_analysis.py
+++ b/modules/management/group_analysis/group_analysis.py
@@ -202,16 +202,20 @@ def choose_group(portfolio: pd.DataFrame) -> str:
             print(f"  {i}) {t}")
         print(f"  {len(unique_ts) + 1}) Create a custom group name")
 
-        choice = input(f"Select 1-{len(unique_ts)+1}: ").strip()
+        choice = input(
+            f"Select 1-{len(unique_ts)+1} (or press Enter to cancel): "
+        ).strip()
+        if not choice:
+            return ""
         if choice.isdigit():
             idx = int(choice)
             if 1 <= idx <= len(unique_ts):
                 return unique_ts[idx - 1]  # use portfolio ticker as group name
-            elif idx == len(unique_ts) + 1:
-                name = input("Enter custom group name: ").strip()
+            if idx == len(unique_ts) + 1:
+                name = input("Enter custom group name (or press Enter to cancel): ").strip()
                 return name if name else ""
     # If portfolio is empty or user skipped above
-    name = input("Enter new group name: ").strip()
+    name = input("Enter new group name (or press Enter to cancel): ").strip()
     return name if name else ""
 
 


### PR DESCRIPTION
## Summary
- alias `run_metadata_checker` so CLI works again
- allow canceling in group creation prompts
- document CLI bug and new prompt wording in UI report

## Testing
- `pytest -q`
- `python scripts/main.py --help | head`

------
https://chatgpt.com/codex/tasks/task_e_684128550ac483278e95273daeb5f0b2