### PR TITLE
Add edge case tests for fetching and dashboard utilities

### DIFF
--- a/BUG_AUDIT_REPORT.md
+++ b/BUG_AUDIT_REPORT.md
@@ -15,6 +15,8 @@
 - **modules/generate_report/__init__.py** – removed unused `run_metadata_checker` import.
 - **tests/test_data_utils_edge.py** – added edge case tests for data utilities.
 - **tests/test_group_analysis.py** – added input-handling tests for ticker confirmation and group selection.
+- **tests/test_excel_dashboard.py** – added empty input and index-based cases for data transposition utilities.
+- **tests/test_fetching.py** – added tests for invalid providers and empty batch requests.
 
 ## Remaining Warnings
 - `modules/management/directus_tools/__init__.py` re-exports a function causing an unused import warning. This is intentional and can be ignored.

--- a/tests/test_excel_dashboard.py
+++ b/tests/test_excel_dashboard.py
@@ -27,6 +27,11 @@ def test_safe_concat_normal():
     assert result.iloc[1].tolist() == ["BBB", 3, 4]
 
 
+def test_safe_concat_normal_empty():
+    result = _safe_concat_normal({})
+    assert result.empty
+
+
 def test_transpose_financials():
     dfs = {
         "AAA": pd.DataFrame({
@@ -59,6 +64,22 @@ def test_transpose_financials():
     assert second_block.iloc[1, 1] == "EPS"
     assert second_block.iloc[1, 2] == 3
     assert pd.isna(second_block.iloc[1, 3])
+
+
+def test_transpose_financials_index_input():
+    dfs = {
+        "AAA": pd.DataFrame({"Revenue": [10, 20]}, index=["2023-06", "2023-03"]),
+        "BBB": pd.DataFrame({"Revenue": [30]}, index=["2023-06"]),
+    }
+    result = _transpose_financials(dfs)
+    assert list(result.columns) == ["Ticker", "Metric", "2023-06", "2023-03"]
+    assert len(result) == 2
+    assert result.iloc[0].tolist() == ["AAA", "Revenue", 10, 20]
+    second = result.iloc[1].tolist()
+    assert second[0] == "BBB"
+    assert second[1] == "Revenue"
+    assert second[2] == 30
+    assert pd.isna(second[3])
 
 
 def test_strip_timezones_removes_tz():

--- a/tests/test_fetching.py
+++ b/tests/test_fetching.py
@@ -1,6 +1,9 @@
 from unittest.mock import MagicMock, patch
 
-from modules.data.fetching import fetch_basic_stock_data, fetch_basic_stock_data_batch
+from modules.data.fetching import (
+    fetch_basic_stock_data,
+    fetch_basic_stock_data_batch,
+)
 
 
 def test_fetch_basic_stock_data_basic():
@@ -177,4 +180,16 @@ def test_fetch_basic_stock_data_batch(monkeypatch):
     df = fetch_basic_stock_data_batch(["AAA", "BBB"])
     assert list(df["Ticker"]) == ["AAA", "BBB"]
     assert df.loc[0, "Market Cap"] == 10
+
+
+def test_fetch_basic_stock_data_invalid_provider():
+    import pytest
+    with pytest.raises(ValueError):
+        fetch_basic_stock_data("AAA", provider="unknown")
+
+
+def test_fetch_basic_stock_data_batch_empty():
+    df = fetch_basic_stock_data_batch([])
+    # Should return DataFrame with BASIC_FIELDS columns but no rows
+    assert df.empty
 


### PR DESCRIPTION
## Summary
- add empty input tests for dashboard helpers
- test invalid provider and empty list cases for fetching
- update bug audit report

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841284c0dc48327858a6f54e8a2bb7e