### PR TITLE
Improve CLI prompts and headings

### DIFF
--- a/UI_IMPROVEMENT_REPORT.md
+++ b/UI_IMPROVEMENT_REPORT.md
@@ -55,3 +55,16 @@ These changes ensure consistent feedback across the CLI and provide clearer guid
 - Clarified group creation prompts in
   `modules/management/group_analysis/group_analysis.py` lines
   205–219 to mention pressing Enter to cancel selections.
+
+### New Enhancements
+
+- Standardized menu headings by calling `print_header` in
+  `portfolio_manager.py`, `settings_manager.py` and `directus_wizard.py`.
+- Added cancel options for removing tickers and deleting groups:
+  - `portfolio_manager.remove_ticker` lines 245–253 allow pressing Enter to cancel.
+  - `group_analysis.remove_ticker_from_group` lines 296–316 handle empty input.
+  - `group_analysis.delete_group` lines 340–347 handle empty input.
+- Viewing notes now accepts an empty title to cancel in
+  `note_manager.py` lines 78–81.
+- Settings modifications can be canceled by leaving the key blank in
+  `settings_manager.py` lines 58–66 and 80–88.

--- a/modules/management/directus_tools/directus_wizard.py
+++ b/modules/management/directus_tools/directus_wizard.py
@@ -1,6 +1,6 @@
 import json
 
-from modules.interface import print_invalid_choice
+from modules.interface import print_invalid_choice, print_header
 
 from modules.data import directus_client as dc
 
@@ -24,7 +24,7 @@ def run_directus_wizard() -> None:
             return
 
     while True:
-        print("\n🧩 Directus Tools")
+        print_header("\U0001F9E9 Directus Tools")
         print("1) List Collections")
         print("2) View Fields in Collection")
         print("3) Add Field to Collection")

--- a/modules/management/group_analysis/group_analysis.py
+++ b/modules/management/group_analysis/group_analysis.py
@@ -293,7 +293,12 @@ def remove_ticker_from_group(groups: pd.DataFrame) -> pd.DataFrame:
     unique_groups = groups["Group"].dropna().unique().tolist()
     for i, g in enumerate(unique_groups, start=1):
         print(f"  {i}) {g}")
-    choice = input(f"Select a group to modify [1-{len(unique_groups)}]: ").strip()
+    choice = input(
+        f"Select a group to modify [1-{len(unique_groups)}] (or press Enter to cancel): "
+    ).strip()
+    if not choice:
+        print("Canceled.\n")
+        return groups
     if not (choice.isdigit() and 1 <= int(choice) <= len(unique_groups)):
         print_invalid_choice()
         return groups
@@ -303,7 +308,12 @@ def remove_ticker_from_group(groups: pd.DataFrame) -> pd.DataFrame:
     members = groups[groups["Group"] == grp]["Ticker"].tolist()
     for i, t in enumerate(members, start=1):
         print(f"  {i}) {t}")
-    idx = input(f"Select ticker to remove (1-{len(members)}): ").strip()
+    idx = input(
+        f"Select ticker to remove (1-{len(members)}) (or press Enter to cancel): "
+    ).strip()
+    if not idx:
+        print("Canceled.\n")
+        return groups
     if not (idx.isdigit() and 1 <= int(idx) <= len(members)):
         print_invalid_choice()
         return groups
@@ -327,7 +337,12 @@ def delete_group(groups: pd.DataFrame) -> pd.DataFrame:
     unique_groups = groups["Group"].dropna().unique().tolist()
     for i, g in enumerate(unique_groups, start=1):
         print(f"  {i}) {g}")
-    choice = input(f"Select a group to delete [1-{len(unique_groups)}]: ").strip()
+    choice = input(
+        f"Select a group to delete [1-{len(unique_groups)}] (or press Enter to cancel): "
+    ).strip()
+    if not choice:
+        print("Canceled.\n")
+        return groups
     if not (choice.isdigit() and 1 <= int(choice) <= len(unique_groups)):
         print_invalid_choice()
         return groups

--- a/modules/management/note_manager/note_manager.py
+++ b/modules/management/note_manager/note_manager.py
@@ -75,7 +75,10 @@ def run_note_manager() -> None:
                 for n in notes:
                     print(f"- {n}")
         elif choice == "2":
-            title = input("Note title: ").strip()
+            title = input("Note title (or press Enter to cancel): ").strip()
+            if not title:
+                print("Canceled.\n")
+                continue
             content = read_note(title)
             if content is None:
                 print("Note not found.")

--- a/modules/management/portfolio_manager/portfolio_manager.py
+++ b/modules/management/portfolio_manager/portfolio_manager.py
@@ -18,7 +18,7 @@ Description:
 import os
 
 from modules.analytics import portfolio_summary, sector_counts
-from modules.interface import print_table, print_invalid_choice
+from modules.interface import print_table, print_invalid_choice, print_header
 
 import pandas as pd
 import requests
@@ -246,9 +246,9 @@ def remove_ticker(portfolio: pd.DataFrame) -> pd.DataFrame:
     """
     Prompt the user for a ticker to remove from the portfolio.
     """
-    tk = input("Enter the ticker symbol to remove: ").strip().upper()
+    tk = input("Enter the ticker symbol to remove (or press Enter to cancel): ").strip().upper()
     if not tk:
-        print("No ticker entered. Returning to main menu.\n")
+        print("Canceled.\n")
         return portfolio
 
     if tk not in portfolio["Ticker"].values:
@@ -300,7 +300,7 @@ def view_portfolio(portfolio: pd.DataFrame):
 
 
 def main():
-    print("\n=== Portfolio Manager ===\n")
+    print_header("\U0001F4C8 Portfolio Manager")
     portfolio = load_portfolio(PORTFOLIO_FILE)
 
     while True:

--- a/modules/management/settings_manager/settings_manager.py
+++ b/modules/management/settings_manager/settings_manager.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Dict
 
-from modules.interface import print_invalid_choice
+from modules.interface import print_invalid_choice, print_header
 
 import importlib
 
@@ -33,7 +33,9 @@ def _discover_wizards():
 
 
 def _prompt_kv() -> tuple[str, str]:
-    key = input("Key: ").strip()
+    key = input("Key (or press Enter to cancel): ").strip()
+    if not key:
+        return "", ""
     value = input("Value: ").strip()
     return key, value
 
@@ -55,6 +57,9 @@ def _show_api_keys() -> None:
 
 def _set_setting() -> None:
     key, val = _prompt_kv()
+    if not key:
+        print("Canceled.\n")
+        return
     data = load_settings()
     data[key] = val
     save_settings(data)
@@ -74,6 +79,9 @@ def _del_setting() -> None:
 
 def _set_env_var() -> None:
     key, val = _prompt_kv()
+    if not key:
+        print("Canceled.\n")
+        return
     env = load_env()
     env[key] = val
     save_env(env)
@@ -92,7 +100,7 @@ def _del_env_var() -> None:
 
 def _general_settings_menu() -> None:
     while True:
-        print("\n⚙️ General Settings")
+        print_header("\u2699\ufe0f General Settings")
         print("1) View settings.json")
         print("2) Set Setting")
         print("3) Delete Setting")
@@ -112,7 +120,7 @@ def _general_settings_menu() -> None:
 
 def _env_menu() -> None:
     while True:
-        print("\n⚙️ Environment (.env)")
+        print_header("\u2699\ufe0f Environment (.env)")
         print("1) View .env")
         print("2) Set .env Variable")
         print("3) Delete .env Variable")
@@ -145,7 +153,7 @@ def _wizards_menu() -> None:
     order = [label for label in default_order if label in wiz_map]
     order.extend([lbl for lbl in wiz_map if lbl not in order])
     while True:
-        print("\n⚙️ Setup Wizards")
+        print_header("\u2699\ufe0f Setup Wizards")
         for idx, lbl in enumerate(order, start=1):
             print(f"{idx}) Setup {lbl}")
         print(f"{len(order)+1}) Return to Settings Menu")
@@ -169,7 +177,7 @@ def run_settings_manager() -> None:
     CONFIG_DIR.mkdir(parents=True, exist_ok=True)
 
     while True:
-        print("\n⚙️ Settings")
+        print_header("\u2699\ufe0f Settings")
         options = [
             ("General Settings", _general_settings_menu),
             ("Environment (.env)", _env_menu),


### PR DESCRIPTION
## Summary
- use `print_header` in portfolio, settings and Directus menus
- add cancel options for removing tickers and deleting groups
- allow cancelling view note prompt
- handle canceling when setting configuration values
- document new enhancements in `UI_IMPROVEMENT_REPORT.md`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68412f89862483279ce79859e6f2e62b