### PR TITLE
Refactor batch fetching and data utils

### DIFF
--- a/CORE_ENHANCEMENT_SUMMARY.md
+++ b/CORE_ENHANCEMENT_SUMMARY.md
@@ -1,6 +1,10 @@
 # Core Enhancement Summary
 
 ## Updated Modules
+- **modules/data/fetching.py** – `fetch_basic_stock_data_batch` now supports a
+  `max_workers` parameter for optional parallel fetching.
+- **modules/utils/data_utils.py** – added `read_json_if_exists` helper for safe
+  JSON ingestion.
 
 - **modules/utils/data_utils.py** – new helper module providing `strip_timezones`, `ensure_period_column`, and `read_csv_if_exists`.
 - **modules/generate_report/excel_dashboard.py** – refactored to use the new utilities, reducing repetitive CSV loading logic and simplifying timezone handling.

--- a/modules/utils/data_utils.py
+++ b/modules/utils/data_utils.py
@@ -4,7 +4,8 @@ from __future__ import annotations
 
 import pandas as pd
 from pathlib import Path
-from typing import Optional
+from typing import Optional, Any
+import json
 
 
 def strip_timezones(df: pd.DataFrame) -> pd.DataFrame:
@@ -31,6 +32,17 @@ def read_csv_if_exists(path: Path, **kwargs) -> Optional[pd.DataFrame]:
     if path.exists():
         try:
             return pd.read_csv(path, **kwargs)
+        except Exception:
+            return None
+    return None
+
+
+def read_json_if_exists(path: Path) -> Optional[Any]:
+    """Return deserialized JSON object from ``path`` if it exists."""
+    if path.exists():
+        try:
+            with open(path, "r", encoding="utf-8") as f:
+                return json.load(f)
         except Exception:
             return None
     return None

--- a/tests/test_data_utils_edge.py
+++ b/tests/test_data_utils_edge.py
@@ -1,5 +1,9 @@
 import pandas as pd
-from modules.utils.data_utils import ensure_period_column, read_csv_if_exists
+from modules.utils.data_utils import (
+    ensure_period_column,
+    read_csv_if_exists,
+    read_json_if_exists,
+)
 
 
 def test_ensure_period_column_existing():
@@ -33,3 +37,16 @@ def test_read_csv_if_exists_success(tmp_path):
     result = read_csv_if_exists(path)
     assert result is not None
     assert result['A'].tolist() == [1]
+
+
+def test_read_json_if_exists(tmp_path):
+    path = tmp_path / 'data.json'
+    data = {"a": 1, "b": 2}
+    path.write_text('{"a": 1, "b": 2}', encoding='utf-8')
+    result = read_json_if_exists(path)
+    assert result == data
+
+
+def test_read_json_if_exists_missing(tmp_path):
+    path = tmp_path / 'missing.json'
+    assert read_json_if_exists(path) is None

--- a/tests/test_fetching.py
+++ b/tests/test_fetching.py
@@ -180,7 +180,9 @@ def test_fetch_basic_stock_data_batch(monkeypatch):
     monkeypatch.setattr("modules.data.fetching.yf.Ticker", lambda s: FakeTicker(s))
     monkeypatch.setattr("modules.data.fetching.resolve_term", lambda x: x)
 
-    df = fetch_basic_stock_data_batch(["AAA", "BBB"], progress=True, dedup=True)
+    df = fetch_basic_stock_data_batch(
+        ["AAA", "BBB"], progress=True, dedup=True, max_workers=2
+    )
     assert list(df["Ticker"]) == ["AAA", "BBB"]
     assert df.loc[0, "Market Cap"] == 10
 


### PR DESCRIPTION
## Summary
- support parallel fetching in `fetch_basic_stock_data_batch`
- add `read_json_if_exists` helper for safe JSON ingestion
- test new helpers and options
- document new capabilities

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684131595bf4832796d2186236629ed2