### PR TITLE
Refactor dashboard writing and add math utilities

### DIFF
--- a/CORE_ENHANCEMENT_SUMMARY.md
+++ b/CORE_ENHANCEMENT_SUMMARY.md
@@ -97,3 +97,18 @@ def fetch_and_compile(...):
     rutils.fetch_financial_statements(...)
     rutils.write_report_and_metadata(...)
 ```
+
+### 2025 Math utilities and fallback improvements
+
+- **modules/utils/math_utils.py** – new helper module providing `moving_average` and `percentage_change`.
+- **modules/analytics/__init__.py** – now re-exports these math helpers.
+- **modules/generate_report/fallback_data.py** – implemented `fetch_1mo_prices_fmp` for FMP-based price retrieval.
+- **modules/generate_report/excel_dashboard.py** – `_write_dashboard` simplified using a loop over table specs.
+- **docs/overview.md** and **docs/API_REFERENCE.md** – updated to document the new math utilities.
+- **tests** – added coverage for `percentage_change` and the FMP price fetch.
+
+```python
+from modules.utils.math_utils import percentage_change
+s = pd.Series([1, 2, 4])
+pct = percentage_change(s)
+```

--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -26,6 +26,22 @@ FILE
     /workspace/Fundalyze/modules/analytics/__init__.py
 
 
+Help on module modules.utils.math_utils in modules.utils:
+
+NAME
+    modules.utils.math_utils - Mathematical helper utilities.
+
+FUNCTIONS
+    moving_average(series: 'pd.Series', window: 'int') -> 'pd.Series'
+        Return rolling mean over ``window`` periods.
+
+    percentage_change(series: 'pd.Series', periods: 'int' = 1) -> 'pd.Series'
+        Return percent change from ``periods`` prior values.
+
+FILE
+    /workspace/Fundalyze/modules/utils/math_utils.py
+
+
 Help on module modules.data.fetching in modules.data:
 
 NAME

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -29,6 +29,12 @@ Lower-level helpers used across the app:
 - `directus_client.py` – optional Directus integration for remote storage.
 - `term_mapper.py` – maps common financial terms to API field names and stores the mapping in `config/term_mapping.json`.
 
+### `modules.utils`
+Small helper utilities reused across the codebase:
+- `data_utils.py` – safe CSV/JSON loading helpers.
+- `excel_utils.py` – convenience wrappers for writing Excel tables.
+- `math_utils.py` – calculations like moving averages and percentage change.
+
 ### `modules.config_utils`
 Loads environment variables from `config/.env` and user settings from `config/settings.json`. Call `load_settings()` once during startup so other modules can access configuration values via `os.getenv()` or the returned dictionary.
 

--- a/modules/analytics/__init__.py
+++ b/modules/analytics/__init__.py
@@ -2,6 +2,15 @@
 from __future__ import annotations
 
 import pandas as pd
+from modules.utils.math_utils import moving_average, percentage_change
+
+__all__ = [
+    "portfolio_summary",
+    "sector_counts",
+    "correlation_matrix",
+    "moving_average",
+    "percentage_change",
+]
 
 
 def portfolio_summary(df: pd.DataFrame) -> pd.DataFrame:
@@ -33,9 +42,3 @@ def correlation_matrix(df: pd.DataFrame) -> pd.DataFrame:
     return df[numeric_cols].corr()
 
 
-def moving_average(series: pd.Series, window: int) -> pd.Series:
-    """Return rolling mean over ``window`` periods."""
-
-    if series is None or series.empty:
-        return pd.Series(dtype="float64")
-    return series.rolling(window=window, min_periods=1).mean()

--- a/modules/generate_report/excel_dashboard.py
+++ b/modules/generate_report/excel_dashboard.py
@@ -101,71 +101,21 @@ def _write_dashboard(
     df_cash_qtr: pd.DataFrame,
 ) -> None:
     """Write all tables to ``dash_path`` as an Excel workbook."""
+    tables = [
+        (df_profiles, "Profile", "Profile_Table", "Table Style Medium 2"),
+        (df_prices, "PriceHistory", "PriceHistory_Table", "Table Style Medium 3"),
+        (df_inc_ann, "Income_Annual", "Income_Annual_Table", "Table Style Medium 4"),
+        (df_inc_qtr, "Income_Quarter", "Income_Quarter_Table", "Table Style Medium 5"),
+        (df_bal_ann, "Balance_Annual", "Balance_Annual_Table", "Table Style Medium 6"),
+        (df_bal_qtr, "Balance_Quarter", "Balance_Quarter_Table", "Table Style Medium 7"),
+        (df_cash_ann, "Cash_Annual", "Cash_Annual_Table", "Table Style Medium 8"),
+        (df_cash_qtr, "Cash_Quarter", "Cash_Quarter_Table", "Table Style Medium 9"),
+    ]
+
     with pd.ExcelWriter(dash_path, engine="xlsxwriter") as writer:
-        if not df_profiles.empty:
-            write_table(
-                writer,
-                df_profiles,
-                "Profile",
-                "Profile_Table",
-                style="Table Style Medium 2",
-            )
-        if not df_prices.empty:
-            write_table(
-                writer,
-                df_prices,
-                "PriceHistory",
-                "PriceHistory_Table",
-                style="Table Style Medium 3",
-            )
-        if not df_inc_ann.empty:
-            write_table(
-                writer,
-                df_inc_ann,
-                "Income_Annual",
-                "Income_Annual_Table",
-                style="Table Style Medium 4",
-            )
-        if not df_inc_qtr.empty:
-            write_table(
-                writer,
-                df_inc_qtr,
-                "Income_Quarter",
-                "Income_Quarter_Table",
-                style="Table Style Medium 5",
-            )
-        if not df_bal_ann.empty:
-            write_table(
-                writer,
-                df_bal_ann,
-                "Balance_Annual",
-                "Balance_Annual_Table",
-                style="Table Style Medium 6",
-            )
-        if not df_bal_qtr.empty:
-            write_table(
-                writer,
-                df_bal_qtr,
-                "Balance_Quarter",
-                "Balance_Quarter_Table",
-                style="Table Style Medium 7",
-            )
-        if not df_cash_ann.empty:
-            write_table(
-                writer,
-                df_cash_ann,
-                "Cash_Annual",
-                "Cash_Annual_Table",
-                style="Table Style Medium 8",
-            )
-        if not df_cash_qtr.empty:
-            write_table(
-                writer,
-                df_cash_qtr,
-                "Cash_Quarter",
-                "Cash_Quarter_Table",
-                style="Table Style Medium 9",
-            )
+        for df, sheet, table, style in tables:
+            if not df.empty:
+                write_table(writer, df, sheet, table, style=style)
 
 
 def _strip_timezones(df: pd.DataFrame) -> pd.DataFrame:

--- a/modules/utils/math_utils.py
+++ b/modules/utils/math_utils.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+"""Mathematical helper utilities."""
+
+import pandas as pd
+
+
+def moving_average(series: pd.Series, window: int) -> pd.Series:
+    """Return rolling mean over ``window`` periods."""
+    if series is None or series.empty:
+        return pd.Series(dtype="float64")
+    return series.rolling(window=window, min_periods=1).mean()
+
+
+def percentage_change(series: pd.Series, periods: int = 1) -> pd.Series:
+    """Return percent change from ``periods`` prior values."""
+    if series is None or series.empty:
+        return pd.Series(dtype="float64")
+    return series.pct_change(periods=periods, fill_method=None)

--- a/tests/test_analysis.py
+++ b/tests/test_analysis.py
@@ -1,7 +1,7 @@
 import pandas as pd
 from analytics import portfolio_summary, sector_counts
 import pytest
-from analytics import correlation_matrix, moving_average
+from analytics import correlation_matrix, moving_average, percentage_change
 
 
 def test_portfolio_summary_numeric_columns():
@@ -55,3 +55,16 @@ def test_moving_average_basic():
     s = pd.Series([1, 2, 3, 4])
     result = moving_average(s, window=2)
     assert result.tolist() == [1.0, 1.5, 2.5, 3.5]
+
+
+def test_percentage_change_basic():
+    s = pd.Series([1, 2, 4])
+    result = percentage_change(s)
+    assert pytest.approx(result.iloc[2]) == 1.0
+    assert pd.isna(result.iloc[0])
+
+
+def test_percentage_change_empty():
+    empty = pd.Series(dtype=float)
+    result = percentage_change(empty)
+    assert result.empty

--- a/tests/test_fallback_data.py
+++ b/tests/test_fallback_data.py
@@ -45,6 +45,49 @@ def test_fetch_fmp_statement(monkeypatch):
     assert df.loc["2023", "Revenue"] == 5
 
 
+def test_fetch_1mo_prices_fmp(monkeypatch):
+    resp = MagicMock()
+    resp.json.return_value = {
+        "historical": [
+            {
+                "date": "2023-01-02",
+                "open": 1,
+                "high": 2,
+                "low": 0.5,
+                "close": 1.5,
+                "adjClose": 1.5,
+                "volume": 100,
+            }
+        ]
+    }
+    resp.raise_for_status.return_value = None
+    monkeypatch.setattr(fb.requests, "get", lambda url: resp)
+
+    df = fb.fetch_1mo_prices_fmp("AAA")
+    assert list(df.columns) == [
+        "Date",
+        "Open",
+        "High",
+        "Low",
+        "Close",
+        "Adj Close",
+        "Volume",
+    ]
+    assert len(df) == 1
+
+
+def test_fetch_1mo_prices_fmp_no_data(monkeypatch):
+    resp = MagicMock()
+    resp.json.return_value = {"historical": []}
+    resp.raise_for_status.return_value = None
+    monkeypatch.setattr(fb.requests, "get", lambda url: resp)
+
+    import pytest
+
+    with pytest.raises(ValueError):
+        fb.fetch_1mo_prices_fmp("AAA")
+
+
 def test_enrich_ticker_folder_updates_files(tmp_path, monkeypatch):
     ticker_dir = tmp_path / "AAA"
     ticker_dir.mkdir()


### PR DESCRIPTION
## Summary
- centralize moving average logic in new `math_utils` module and expose `percentage_change`
- update analytics package to re-export math helpers
- implement FMP price history fetch in fallback module
- simplify Excel dashboard creation loop
- document new utilities in API and overview docs
- expand tests for new features

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68413a792cfc8327a1adaa2d25a9d077