### PR TITLE
Add directus field mapping

### DIFF
--- a/config/directus_field_map.json
+++ b/config/directus_field_map.json
@@ -1,0 +1,14 @@
+{
+  "companies": {
+    "Ticker": "ticker_symbol",
+    "Name": "company_name",
+    "Sector": "sector",
+    "Industry": "industry",
+    "Country": "country",
+    "Market": "market",
+    "Logo": "logo",
+    "Website": "website",
+    "Company Information": "Company_Information",
+    "Notes": "notes"
+  }
+}

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -45,6 +45,12 @@ The timezone can be changed later by running the **Timezone** wizard inside the
 Settings Manager. Additional wizards help configure Directus connectivity and the notes directory.
 `load_settings()` returns the parsed dictionary so other modules can access these values.
 
+## Directus Field Mapping
+`config/directus_field_map.json` defines how local field names map to your Directus collections.
+Each key is a collection name with a dictionary mapping local column names to the
+corresponding Directus field. Adjust this file if you rename fields or add new
+attributes to Directus.
+
 ## Initial Setup
 1. Clone the repository and run one of the `bootstrap_env` scripts to create a virtual environment and install dependencies.
 2. Populate `config/.env` and optionally `config/settings.json` as shown above.

--- a/modules/data/__init__.py
+++ b/modules/data/__init__.py
@@ -17,6 +17,7 @@ from .directus_client import (
 )
 from .term_mapper import load_mapping, save_mapping, resolve_term, add_alias
 from .compare import interactive_profile, diff_dict
+from .directus_mapper import load_field_map, save_field_map, prepare_records
 
 __all__ = [
     "fetch_basic_stock_data",
@@ -34,4 +35,7 @@ __all__ = [
     "add_alias",
     "interactive_profile",
     "diff_dict",
+    "load_field_map",
+    "save_field_map",
+    "prepare_records",
 ]

--- a/modules/data/directus_mapper.py
+++ b/modules/data/directus_mapper.py
@@ -1,0 +1,42 @@
+import json
+from pathlib import Path
+from typing import Iterable, Dict, Any, List
+
+from .directus_client import list_fields
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+MAP_FILE = PROJECT_ROOT / "config" / "directus_field_map.json"
+
+
+def load_field_map() -> Dict[str, Dict[str, str]]:
+    """Return mapping dictionary loaded from ``config/directus_field_map.json``."""
+    if MAP_FILE.is_file():
+        with open(MAP_FILE, "r", encoding="utf-8") as f:
+            return json.load(f)
+    return {}
+
+
+def save_field_map(mapping: Dict[str, Dict[str, str]]) -> None:
+    """Save mapping dictionary to ``config/directus_field_map.json``."""
+    MAP_FILE.parent.mkdir(parents=True, exist_ok=True)
+    with open(MAP_FILE, "w", encoding="utf-8") as f:
+        json.dump(mapping, f, indent=2)
+
+
+def prepare_records(collection: str, records: Iterable[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    """Rename and filter record fields for Directus insertion."""
+    mapping = load_field_map().get(collection, {})
+    try:
+        allowed = set(list_fields(collection))
+    except Exception:
+        allowed = set()
+
+    prepared: List[Dict[str, Any]] = []
+    for row in records:
+        mapped = {}
+        for key, value in row.items():
+            new_key = mapping.get(key, key)
+            if not allowed or new_key in allowed:
+                mapped[new_key] = value
+        prepared.append(mapped)
+    return prepared

--- a/modules/management/directus_tools/directus_wizard.py
+++ b/modules/management/directus_tools/directus_wizard.py
@@ -2,7 +2,7 @@ import json
 
 from modules.interface import print_invalid_choice, print_header
 
-from modules.data import directus_client as dc
+from modules.data import directus_client as dc, prepare_records
 
 try:
     from modules.management.settings_manager.wizards.directus_setup import (
@@ -66,7 +66,8 @@ def run_directus_wizard() -> None:
                 except Exception as exc:
                     print(f"Invalid JSON: {exc}\n")
                 else:
-                    dc.insert_items(col, [data])
+                    records = prepare_records(col, [data])
+                    dc.insert_items(col, records)
                     print("Item inserted.\n")
         elif choice == "6":
             break

--- a/modules/management/group_analysis/group_analysis.py
+++ b/modules/management/group_analysis/group_analysis.py
@@ -32,7 +32,8 @@ SETTINGS = load_settings()
 import pandas as pd
 import requests
 from modules.data.term_mapper import resolve_term
-from modules.data.directus_client import fetch_items, insert_items, list_fields
+from modules.data.directus_client import fetch_items, insert_items
+from modules.data import prepare_records
 
 PORTFOLIO_FILE = "portfolio.xlsx"
 GROUPS_FILE = "groups.xlsx"
@@ -103,10 +104,7 @@ def save_groups(df: pd.DataFrame, filepath: str):
     """
     if USE_DIRECTUS:
         try:
-            allowed = set(list_fields(GROUPS_COLLECTION))
-            records = []
-            for row in df.to_dict(orient="records"):
-                records.append({k: v for k, v in row.items() if k in allowed})
+            records = prepare_records(GROUPS_COLLECTION, df.to_dict(orient="records"))
             insert_items(GROUPS_COLLECTION, records)
             print(
                 f"→ Saved groups to Directus collection '{GROUPS_COLLECTION}'.\n"

--- a/modules/management/portfolio_manager/portfolio_manager.py
+++ b/modules/management/portfolio_manager/portfolio_manager.py
@@ -26,8 +26,8 @@ from modules.data.term_mapper import resolve_term
 from modules.data.directus_client import (
     fetch_items,
     insert_items,
-    list_fields,
 )
+from modules.data import prepare_records
 
 PORTFOLIO_FILE = "portfolio.xlsx"
 C_DIRECTUS_COLLECTION = os.getenv("DIRECTUS_PORTFOLIO_COLLECTION", "portfolio")
@@ -83,11 +83,7 @@ def save_portfolio(df: pd.DataFrame, filepath: str):
     """
     if USE_DIRECTUS:
         try:
-            allowed = set(list_fields(C_DIRECTUS_COLLECTION))
-            records = []
-            for row in df.to_dict(orient="records"):
-                filtered = {k: v for k, v in row.items() if k in allowed}
-                records.append(filtered)
+            records = prepare_records(C_DIRECTUS_COLLECTION, df.to_dict(orient="records"))
             insert_items(C_DIRECTUS_COLLECTION, records)
             print(
                 f"→ Saved portfolio to Directus collection '{C_DIRECTUS_COLLECTION}'.\n"

--- a/tests/test_directus_mapper.py
+++ b/tests/test_directus_mapper.py
@@ -1,0 +1,20 @@
+from pathlib import Path
+import json
+import modules.data.directus_mapper as dm
+
+
+def test_map_file_location():
+    repo_root = Path(__file__).resolve().parents[1]
+    assert dm.MAP_FILE == repo_root / "config" / "directus_field_map.json"
+
+
+def test_prepare_records(monkeypatch, tmp_path):
+    mapping = {"companies": {"Ticker": "ticker_symbol", "Name": "company_name"}}
+    file = tmp_path / "directus_field_map.json"
+    file.write_text(json.dumps(mapping))
+    monkeypatch.setattr(dm, "MAP_FILE", file)
+    monkeypatch.setattr(dm, "list_fields", lambda c: ["ticker_symbol", "company_name"])
+
+    records = [{"Ticker": "AAA", "Name": "Acme", "Extra": 1}]
+    prepared = dm.prepare_records("companies", records)
+    assert prepared == [{"ticker_symbol": "AAA", "company_name": "Acme"}]

--- a/tests/test_group_analysis.py
+++ b/tests/test_group_analysis.py
@@ -13,12 +13,12 @@ def test_load_groups_directus(monkeypatch):
 
 def test_save_groups_directus(monkeypatch):
     monkeypatch.setattr(ga, "USE_DIRECTUS", True)
-    monkeypatch.setattr(ga, "list_fields", lambda c: ["Group", "Ticker", "Name"])
+    monkeypatch.setattr(ga, "prepare_records", lambda c, recs: [recs[0]])
     captured = {}
     monkeypatch.setattr(ga, "insert_items", lambda c, recs: captured.setdefault("rec", recs))
     df = pd.DataFrame({"Group": ["G"], "Ticker": ["AAA"], "Name": ["Alpha"], "Extra": [1]})
     ga.save_groups(df, "dummy.xlsx")
-    assert captured["rec"] == [{"Group": "G", "Ticker": "AAA", "Name": "Alpha"}]
+    assert captured["rec"] == [df.to_dict(orient="records")[0]]
 
 
 def test_confirm_or_adjust_ticker_yes(monkeypatch):

--- a/tests/test_portfolio_manager.py
+++ b/tests/test_portfolio_manager.py
@@ -22,11 +22,9 @@ def test_load_portfolio_directus(monkeypatch):
 
 def test_save_portfolio_directus(monkeypatch):
     monkeypatch.setattr(pm, "USE_DIRECTUS", True)
-    monkeypatch.setattr(pm, "list_fields", lambda c: ["Ticker", "Name"])
+    monkeypatch.setattr(pm, "prepare_records", lambda c, recs: [recs[0]])
     records_holder = {}
-    def fake_insert(collection, records):
-        records_holder['rec'] = records
-    monkeypatch.setattr(pm, "insert_items", fake_insert)
+    monkeypatch.setattr(pm, "insert_items", lambda c, recs: records_holder.setdefault('rec', recs))
     df = pd.DataFrame({"Ticker": ["A"], "Name": ["Acme"], "Extra": [1]})
     pm.save_portfolio(df, "dummy")
-    assert records_holder['rec'] == [{"Ticker": "A", "Name": "Acme"}]
+    assert records_holder['rec'] == [df.to_dict(orient="records")[0]]


### PR DESCRIPTION
## Summary
- support field name mapping for Directus
- hook mapping into portfolio/groups saving
- map fields when inserting via Directus wizard
- document `config/directus_field_map.json`
- tests for new mapper

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841488ade7c8327a2fa80b20cb0c635