### PR TITLE
Add interactive Directus field mapping sync

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,40 @@ excel_dashboard.create_and_open_dashboard(tickers=["AAPL"])
 Open the workbook to explore profile information, price history and
 statements.
 
+## Directus Field Mapping
+
+The script `scripts/sync_directus_fields.py` automatically fetches all collections
+and fields from the connected Directus instance and merges them into
+`directus_field_map.json`.
+
+**Usage:**
+1. Ensure `DIRECTUS_API_URL` and `DIRECTUS_TOKEN` (or Directus credentials) are
+   configured in your environment.
+2. Run:
+```bash
+python scripts/sync_directus_fields.py
+```
+3. You will be prompted to:
+   - Map new fields to target names.
+   - Confirm type changes.
+   - Remove fields or collections deleted from Directus.
+
+**`directus_field_map.json` Structure:**
+```jsonc
+{
+  "collections": {
+    "portfolio": {
+      "fields": {
+        "id": { "type": "integer", "mapped_to": "portfolio_id" },
+        "ticker": { "type": "string", "mapped_to": "symbol" }
+      }
+    }
+  }
+}
+```
+After merging, any unmapped fields will have `"mapped_to": null` and you will be
+prompted to set them before the script exits.
+
 ## Folder Structure
 
 - `modules/` – source code packages

--- a/directus_field_map_example.json
+++ b/directus_field_map_example.json
@@ -1,0 +1,20 @@
+{
+  "collections": {
+    "portfolio": {
+      "fields": {
+        "id": {
+          "type": "integer",
+          "mapped_to": "portfolio_id"
+        },
+        "ticker": {
+          "type": "string",
+          "mapped_to": "symbol"
+        },
+        "note": {
+          "type": "text",
+          "mapped_to": null
+        }
+      }
+    }
+  }
+}

--- a/modules/data/directus_client.py
+++ b/modules/data/directus_client.py
@@ -60,6 +60,15 @@ def list_fields(collection: str) -> list[str]:
     return [f.get("field") for f in data]
 
 
+def list_fields_with_types(collection: str) -> list[Dict[str, Any]]:
+    """Return field metadata including name and type for a collection."""
+    data = directus_request("GET", f"fields/{collection}").get("data", [])
+    fields = []
+    for f in data:
+        fields.append({"field": f.get("field"), "type": f.get("type")})
+    return fields
+
+
 def fetch_items(collection: str):
     """Fetch all items from a Directus collection."""
     data = directus_request("GET", f"items/{collection}").get("data", [])

--- a/scripts/sync_directus_fields.py
+++ b/scripts/sync_directus_fields.py
@@ -1,0 +1,124 @@
+#!/usr/bin/env python3
+"""Synchronize Directus field mappings with an interactive CLI."""
+from __future__ import annotations
+
+import json
+from typing import Any, Dict, List
+
+from modules.data.directus_client import (
+    list_collections,
+    list_fields_with_types,
+)
+from modules.data.directus_mapper import load_field_map, save_field_map, MAP_FILE
+
+
+def prompt_user(question: str, options: List[str]) -> str:
+    opts = [o.lower() for o in options]
+    while True:
+        resp = input(question).strip().lower()
+        if resp in opts:
+            return resp
+        print(f"Enter one of: {', '.join(options)}")
+
+
+def summarize_changes(changes: Dict[str, Any]) -> None:
+    print("\nSummary of changes:")
+    if changes.get("collections_added"):
+        print("  Collections added:", ", ".join(changes["collections_added"]))
+    if changes.get("collections_removed"):
+        print("  Collections removed:", ", ".join(changes["collections_removed"]))
+    if changes.get("fields_added"):
+        for col, flds in changes["fields_added"].items():
+            print(f"  Fields added to {col}: {', '.join(flds)}")
+    if changes.get("fields_removed"):
+        for col, flds in changes["fields_removed"].items():
+            print(f"  Fields removed from {col}: {', '.join(flds)}")
+    if changes.get("types_updated"):
+        print("  Types updated:", ", ".join(changes["types_updated"]))
+
+
+def main() -> None:
+    mapping = load_field_map()
+    collections_map = mapping.setdefault("collections", {})
+    changes: Dict[str, Any] = {
+        "collections_added": [],
+        "collections_removed": [],
+        "fields_added": {},
+        "fields_removed": {},
+        "types_updated": [],
+    }
+
+    try:
+        directus_cols = list_collections()
+    except Exception as exc:  # pragma: no cover - network
+        print(f"Failed to fetch collections: {exc}")
+        return
+
+    existing_cols = set(collections_map.keys())
+    for col in directus_cols:
+        if col not in existing_cols:
+            print(f'New collection detected: "{col}"')
+            collections_map[col] = {"fields": {}}
+            changes["collections_added"].append(col)
+
+    for col in existing_cols - set(directus_cols):
+        choice = prompt_user(
+            f'Collection "{col}" no longer exists. Remove from JSON? [yes/no]: ',
+            ["yes", "no"],
+        )
+        if choice == "yes":
+            del collections_map[col]
+            changes["collections_removed"].append(col)
+
+    for col in directus_cols:
+        try:
+            fields = list_fields_with_types(col)
+        except Exception as exc:  # pragma: no cover - network
+            print(f"Failed to fetch fields for '{col}': {exc}")
+            continue
+        col_entry = collections_map.setdefault(col, {"fields": {}})
+        fields_map = col_entry.setdefault("fields", {})
+
+        existing_fields = set(fields_map.keys())
+        directus_fields = {f["field"]: f.get("type") for f in fields}
+
+        for fname, ftype in directus_fields.items():
+            if fname not in existing_fields:
+                print(
+                    f'\n[NEW FIELD] Collection "{col}", field "{fname}" (type: "{ftype}")'
+                )
+                target = input(
+                    "Enter target name (or press Enter to keep same): "
+                ).strip() or fname
+                fields_map[fname] = {"type": ftype, "mapped_to": target}
+                changes.setdefault("fields_added", {}).setdefault(col, []).append(fname)
+            else:
+                current_type = fields_map[fname].get("type")
+                if current_type != ftype:
+                    choice = prompt_user(
+                        f'\n[TYPE CHANGE] "{fname}" in "{col}" was "{current_type}", now "{ftype}". Update type in JSON? [yes/no]: ',
+                        ["yes", "no"],
+                    )
+                    if choice == "yes":
+                        fields_map[fname]["type"] = ftype
+                        changes.setdefault("types_updated", []).append(f"{col}.{fname}")
+
+        for fname in existing_fields - set(directus_fields.keys()):
+            choice = prompt_user(
+                f'\n[DELETED FIELD] "{fname}" in "{col}" no longer exists in Directus. Remove from JSON? [yes/no]: ',
+                ["yes", "no"],
+            )
+            if choice == "yes":
+                del fields_map[fname]
+                changes.setdefault("fields_removed", {}).setdefault(col, []).append(fname)
+
+    summarize_changes(changes)
+    if prompt_user("\nProceed to write changes to directus_field_map.json? [yes/no]: ", ["yes", "no"]) == "yes":
+        save_field_map(mapping)
+        print("directus_field_map.json updated successfully.")
+    else:
+        print("Aborted; no changes saved.")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_directus_client.py
+++ b/tests/test_directus_client.py
@@ -21,6 +21,17 @@ def test_list_fields(monkeypatch):
     assert fields == ["a", "b"]
 
 
+def test_list_fields_with_types(monkeypatch):
+    monkeypatch.setattr(dc, "DIRECTUS_URL", "http://api")
+    monkeypatch.setattr(
+        dc,
+        "directus_request",
+        lambda m, p, **kw: {"data": [{"field": "a", "type": "string"}]},
+    )
+    fields = dc.list_fields_with_types("col")
+    assert fields == [{"field": "a", "type": "string"}]
+
+
 def test_fetch_items(monkeypatch):
     monkeypatch.setattr(dc, "DIRECTUS_URL", "http://api")
     monkeypatch.setattr(dc, "directus_request", lambda m, p, **kw: {"data": [{"x": 1}]})

--- a/tests/test_sync_directus_fields.py
+++ b/tests/test_sync_directus_fields.py
@@ -1,0 +1,82 @@
+import importlib
+import json
+from pathlib import Path
+
+import modules.data.directus_mapper as dm
+
+
+def test_sync_add_collection_and_field(monkeypatch, tmp_path):
+    file = tmp_path / "directus_field_map.json"
+    file.write_text(json.dumps({"collections": {}}))
+    monkeypatch.setattr(dm, "MAP_FILE", file)
+
+    monkeypatch.setattr(dm, "MAP_FILE", file)
+    monkeypatch.setenv("DIRECTUS_URL", "http://api")
+    import modules.data.directus_client as dc
+    monkeypatch.setattr(dc, "DIRECTUS_URL", "http://api")
+
+    monkeypatch.setattr(
+        dm, "list_collections", lambda: ["stocks"]
+    )
+    monkeypatch.setattr(
+        dm, "list_fields_with_types", lambda c: [
+            {"field": "id", "type": "integer"},
+            {"field": "name", "type": "string"},
+        ]
+    )
+
+    module = importlib.import_module("scripts.sync_directus_fields")
+    monkeypatch.setattr(module, "list_collections", lambda: ["stocks"])
+    monkeypatch.setattr(
+        module,
+        "list_fields_with_types",
+        lambda c: [
+            {"field": "id", "type": "integer"},
+            {"field": "name", "type": "string"},
+        ],
+    )
+    inputs = iter(["", "", "yes"])
+    monkeypatch.setattr("builtins.input", lambda *args: next(inputs))
+    monkeypatch.setattr(module, "MAP_FILE", file)
+    monkeypatch.setattr(module, "load_field_map", dm.load_field_map)
+    monkeypatch.setattr(module, "save_field_map", dm.save_field_map)
+    module.main()
+
+    data = json.loads(file.read_text())
+    assert data["collections"]["stocks"]["fields"]["id"]["mapped_to"] == "id"
+    assert "name" in data["collections"]["stocks"]["fields"]
+
+
+def test_sync_handle_deletion_and_type_change(monkeypatch, tmp_path):
+    mapping = {
+        "collections": {
+            "stocks": {
+                "fields": {
+                    "id": {"type": "integer", "mapped_to": "id"},
+                    "name": {"type": "string", "mapped_to": "name"},
+                }
+            }
+        }
+    }
+    file = tmp_path / "directus_field_map.json"
+    file.write_text(json.dumps(mapping))
+    monkeypatch.setattr(dm, "MAP_FILE", file)
+
+    import modules.data.directus_client as dc
+    monkeypatch.setattr(dc, "DIRECTUS_URL", "http://api")
+
+    module = importlib.import_module("scripts.sync_directus_fields")
+    monkeypatch.setattr(module, "list_collections", lambda: ["stocks"])
+    monkeypatch.setattr(module, "list_fields_with_types", lambda c: [{"field": "id", "type": "string"}])
+
+    inputs = iter(["yes", "yes", "yes"])
+    monkeypatch.setattr("builtins.input", lambda *args: next(inputs))
+    monkeypatch.setattr(module, "MAP_FILE", file)
+    monkeypatch.setattr(module, "load_field_map", dm.load_field_map)
+    monkeypatch.setattr(module, "save_field_map", dm.save_field_map)
+    module.main()
+
+    data = json.loads(file.read_text())
+    fields = data["collections"]["stocks"]["fields"]
+    assert "name" not in fields
+    assert fields["id"]["type"] == "string"


### PR DESCRIPTION
## Summary
- support listing fields with types via `list_fields_with_types`
- update Directus mapper to handle new mapping format
- implement `sync_directus_fields.py` CLI with prompts
- document Directus field mapping workflow
- provide example mapping file
- test interactive sync and mapper changes

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68415556bc90832799e59245aa48d12f