### PR TITLE
Improve group selection cancel option

### DIFF
--- a/UI_IMPROVEMENT_REPORT.md
+++ b/UI_IMPROVEMENT_REPORT.md
@@ -84,3 +84,10 @@ These changes ensure consistent feedback across the CLI and provide clearer guid
   See lines 11–28 and 32–36 for the argument parser.
 - `scripts/note_cli.py` injects `sys.path` so running the script directly works
   and exposes a help flag. See lines 4–27.
+
+### Latest Fixes
+
+- Improved the group selection prompt in `_select_tickers` to allow pressing
+  Enter to cancel. See `modules/generate_report/__init__.py` lines 53–63.
+- Manual ticker entry now prints "No tickers entered" when blank to clarify the
+  cancellation path. See lines 31–38 of the same file.

--- a/modules/generate_report/__init__.py
+++ b/modules/generate_report/__init__.py
@@ -32,6 +32,9 @@ def _select_tickers() -> list[str]:
         raw = input(
             "Enter ticker symbol(s), comma-separated (or press Enter to cancel): "
         ).strip()
+        if not raw:
+            print("No tickers entered.\n")
+            return []
         return [t.strip().upper() for t in raw.split(",") if t.strip()]
 
     if choice == "2":
@@ -46,7 +49,12 @@ def _select_tickers() -> list[str]:
             return []
         for i, g in enumerate(names, start=1):
             print(f"  {i}) {g}")
-        sel = input(f"Select a group [1-{len(names)}]: ").strip()
+        sel = input(
+            f"Select a group [1-{len(names)}] (or press Enter to cancel): "
+        ).strip()
+        if not sel:
+            print("Canceled.\n")
+            return []
         if sel.isdigit() and 1 <= int(sel) <= len(names):
             grp = names[int(sel) - 1]
             df = groups[groups["Group"] == grp]


### PR DESCRIPTION
## Summary
- allow blank manual ticker entry
- enable cancelation when choosing a group in `_select_tickers`
- document new fixes in UI improvement report

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684155d7d1688327afd6d44cb4932daf