### PR TITLE
Add interactive field mapping helper

### DIFF
--- a/modules/data/__init__.py
+++ b/modules/data/__init__.py
@@ -22,6 +22,7 @@ from .directus_mapper import (
     save_field_map,
     prepare_records,
     refresh_field_map,
+    ensure_field_mapping,
 )
 
 __all__ = [
@@ -44,4 +45,5 @@ __all__ = [
     "save_field_map",
     "prepare_records",
     "refresh_field_map",
+    "ensure_field_mapping",
 ]

--- a/modules/data/directus_mapper.py
+++ b/modules/data/directus_mapper.py
@@ -82,3 +82,45 @@ def refresh_field_map() -> Dict[str, Any]:
 
     save_field_map(mapping)
     return mapping
+
+
+def ensure_field_mapping(collection: str, df: "pd.DataFrame") -> Dict[str, Any]:
+    """Interactive mapping helper for DataFrame columns.
+
+    For each column in ``df`` that is unmapped or mapped to a non-existent
+    Directus field, prompt the user for the target field name. The mapping file
+    is updated and returned.
+    """
+
+    import pandas as pd  # local import to avoid heavy dependency at startup
+
+    if not isinstance(df, pd.DataFrame):  # pragma: no cover - defensive
+        raise TypeError("df must be a pandas DataFrame")
+
+    mapping = load_field_map()
+    collections = mapping.setdefault("collections", {})
+    col_entry = collections.setdefault(collection, {"fields": {}})
+    fields_map = col_entry.setdefault("fields", {})
+
+    try:
+        allowed = list_fields(collection)
+    except Exception:  # pragma: no cover - network/Directus unavailable
+        allowed = []
+
+    changed = False
+    for column in df.columns:
+        entry = fields_map.get(column)
+        target = entry.get("mapped_to") if entry else None
+        if not target or (allowed and target not in allowed):
+            if allowed:
+                print(f"Available Directus fields for '{collection}': {', '.join(allowed)}")
+            prompt = f"Map column '{column}' to Directus field: "
+            new_target = input(prompt).strip()
+            if new_target:
+                fields_map[column] = {"type": entry.get("type") if entry else None, "mapped_to": new_target}
+                changed = True
+
+    if changed:
+        save_field_map(mapping)
+
+    return mapping

--- a/tests/test_directus_mapper_extra.py
+++ b/tests/test_directus_mapper_extra.py
@@ -1,0 +1,32 @@
+import json
+import pandas as pd
+import modules.data.directus_mapper as dm
+
+
+def test_ensure_field_mapping_new(monkeypatch, tmp_path):
+    mapping = {"collections": {"stocks": {"fields": {"A": {"mapped_to": "a"}}}}}
+    file = tmp_path / "directus_field_map.json"
+    file.write_text(json.dumps(mapping))
+    monkeypatch.setattr(dm, "MAP_FILE", file)
+    monkeypatch.setattr(dm, "list_fields", lambda c: ["a", "b", "c"])
+    inputs = iter(["c"])
+    monkeypatch.setattr("builtins.input", lambda *args: next(inputs))
+    df = pd.DataFrame(columns=["A", "C"])
+    dm.ensure_field_mapping("stocks", df)
+    data = json.loads(file.read_text())
+    assert data["collections"]["stocks"]["fields"]["C"]["mapped_to"] == "c"
+
+
+def test_ensure_field_mapping_invalid(monkeypatch, tmp_path):
+    mapping = {"collections": {"stocks": {"fields": {"A": {"mapped_to": "x"}}}}}
+    file = tmp_path / "directus_field_map.json"
+    file.write_text(json.dumps(mapping))
+    monkeypatch.setattr(dm, "MAP_FILE", file)
+    monkeypatch.setattr(dm, "list_fields", lambda c: ["a", "b"])
+    inputs = iter(["a"])
+    monkeypatch.setattr("builtins.input", lambda *args: next(inputs))
+    df = pd.DataFrame(columns=["A"])
+    dm.ensure_field_mapping("stocks", df)
+    data = json.loads(file.read_text())
+    assert data["collections"]["stocks"]["fields"]["A"]["mapped_to"] == "a"
+


### PR DESCRIPTION
## Summary
- add `ensure_field_mapping` in `directus_mapper` to prompt for unmapped/invalid columns
- expose function via `modules.data`
- test interactive mapping behaviour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68415a2f686c8327a214e83b1178ca83