### PR TITLE
Fix ambiguous NA check in portfolio manager

### DIFF
--- a/REPORT_FIX_TICKER_NA.md
+++ b/REPORT_FIX_TICKER_NA.md
@@ -1,0 +1,30 @@
+## Fix for "NA boolean ambiguous" in portfolio_manager
+
+**Original Error Traceback:** when adding a ticker, the interactive menu crashed with:
+```
+TypeError: boolean value of NA is ambiguous
+```
+originating from `portfolio_manager.py` line 198.
+
+**Before:** membership checks used raw `.values` which may contain `pd.NA`:
+```python
+if tk in portfolio["Ticker"].values:
+```
+
+**After:** drop `NA` values before membership tests via helper `ticker_exists`:
+```python
+existing = df["Ticker"].dropna().astype(str).values
+return tk in existing
+```
+Calls were updated to use `ticker_exists(...)`.
+
+**Files Modified**
+- `modules/management/portfolio_manager/portfolio_manager.py`
+- `modules/management/group_analysis/group_analysis.py`
+- `tests/test_portfolio_manager.py`
+- `REPORT_FIX_TICKER_NA.md`
+
+**New Tests Added**
+- `test_existing_ticker_with_na_skips_adding` – ensures duplicate tickers are skipped even with `pd.NA` present.
+- `test_add_new_ticker_with_nas_present` – verifies adding a new ticker when existing column has NAs.
+- `test_add_ticker_to_all_na_column` – verifies adding when column is entirely `NA`.

--- a/modules/management/group_analysis/group_analysis.py
+++ b/modules/management/group_analysis/group_analysis.py
@@ -400,7 +400,8 @@ def main():
                 print("No group name entered; canceling.\n")
             else:
                 # If group already exists, notify; otherwise create empty placeholder row
-                if grp_name in groups["Group"].values:
+                existing = groups["Group"].dropna().astype(str).values
+                if grp_name in existing:
                     print(f"Group '{grp_name}' already exists. You can add members later.\n")
                 else:
                     # Create an empty placeholder row so group shows up

--- a/modules/management/portfolio_manager/portfolio_manager.py
+++ b/modules/management/portfolio_manager/portfolio_manager.py
@@ -178,6 +178,12 @@ def confirm_or_adjust_ticker(original: str) -> str:
             print("  Please answer 'Y' or 'N'.")
 
 
+def ticker_exists(df: pd.DataFrame, tk: str) -> bool:
+    """Return True if the ticker already exists in the portfolio."""
+    existing = df["Ticker"].dropna().astype(str).values
+    return tk in existing
+
+
 def add_tickers(portfolio: pd.DataFrame) -> pd.DataFrame:
     """
     Prompt the user to enter one or more tickers to add. For each ticker:
@@ -195,7 +201,7 @@ def add_tickers(portfolio: pd.DataFrame) -> pd.DataFrame:
     tickers = [t.strip().upper() for t in raw.split(",") if t.strip()]
     for tk in tickers:
         # If ticker already in portfolio, skip it
-        if tk in portfolio["Ticker"].values:
+        if ticker_exists(portfolio, tk):
             print(f"  → Ticker '{tk}' is already in your portfolio. Skipping.\n")
             continue
 
@@ -253,7 +259,7 @@ def remove_ticker(portfolio: pd.DataFrame) -> pd.DataFrame:
         print("Canceled.\n")
         return portfolio
 
-    if tk not in portfolio["Ticker"].values:
+    if not ticker_exists(portfolio, tk):
         print(f"  × Ticker '{tk}' not found in portfolio.\n")
     else:
         portfolio = portfolio[portfolio["Ticker"] != tk].reset_index(drop=True)


### PR DESCRIPTION
## Summary
- prevent `TypeError: boolean value of NA is ambiguous` when adding tickers
- add `ticker_exists` helper and use it in portfolio and group managers
- add regression tests for NA ticker column handling
- document fix in `REPORT_FIX_TICKER_NA.md`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684165824e0483279c75f27158a7567e