### PR TITLE
Fix Directus NaN row handling

### DIFF
--- a/modules/management/group_analysis/group_analysis.py
+++ b/modules/management/group_analysis/group_analysis.py
@@ -53,6 +53,21 @@ COLUMNS = [
     "Dividend Yield",
 ]
 
+# Possible mapping of Directus field names to our expected columns
+FROM_DIRECTUS = {
+    "group": "Group",
+    "ticker": "Ticker",
+    "ticker_symbol": "Ticker",
+    "company_name": "Name",
+    "name": "Name",
+    "sector": "Sector",
+    "industry": "Industry",
+    "current_price": "Current Price",
+    "market_cap": "Market Cap",
+    "pe_ratio": "PE Ratio",
+    "dividend_yield": "Dividend Yield",
+}
+
 
 def load_portfolio(filepath: str) -> pd.DataFrame:
     """
@@ -78,9 +93,13 @@ def load_groups(filepath: str) -> pd.DataFrame:
             if not records:
                 return pd.DataFrame(columns=COLUMNS)
             df = pd.DataFrame(records)
+            df = df.rename(columns=FROM_DIRECTUS)
             for col in COLUMNS:
                 if col not in df.columns:
                     df[col] = pd.NA
+            df = df.dropna(how="all")
+            if "Group" in df.columns:
+                df = df[df["Group"].notna()]
             return df[COLUMNS]
         except Exception as exc:
             print(f"Error loading groups from Directus: {exc}")
@@ -92,6 +111,9 @@ def load_groups(filepath: str) -> pd.DataFrame:
             for col in COLUMNS:
                 if col not in df.columns:
                     df[col] = pd.NA
+            df = df.dropna(how="all")
+            if "Group" in df.columns:
+                df = df[df["Group"].notna()]
             return df[COLUMNS]
         except Exception as e:
             print(f"Error reading {filepath}: {e}\nStarting with empty groups.")

--- a/modules/management/portfolio_manager/portfolio_manager.py
+++ b/modules/management/portfolio_manager/portfolio_manager.py
@@ -43,6 +43,18 @@ COLUMNS = [
     "Dividend Yield"
 ]
 
+# Mapping of Directus field names to our dataframe columns when reading
+FROM_DIRECTUS = {
+    "ticker_symbol": "Ticker",
+    "company_name": "Name",
+    "sector": "Sector",
+    "industry": "Industry",
+    "current_price": "Current Price",
+    "market_cap": "Market Cap",
+    "pe_ratio": "PE Ratio",
+    "dividend_yield": "Dividend Yield",
+}
+
 
 def load_portfolio(filepath: str) -> pd.DataFrame:
     """
@@ -56,9 +68,13 @@ def load_portfolio(filepath: str) -> pd.DataFrame:
             if not records:
                 return pd.DataFrame(columns=COLUMNS)
             df = pd.DataFrame(records)
+            df = df.rename(columns=FROM_DIRECTUS)
             for col in COLUMNS:
                 if col not in df.columns:
                     df[col] = pd.NA
+            df = df.dropna(how="all")
+            if "Ticker" in df.columns:
+                df = df[df["Ticker"].notna()]
             return df[COLUMNS]
         except Exception as exc:
             print(f"Error loading portfolio from Directus: {exc}")
@@ -70,6 +86,9 @@ def load_portfolio(filepath: str) -> pd.DataFrame:
             for col in COLUMNS:
                 if col not in df.columns:
                     df[col] = pd.NA
+            df = df.dropna(how="all")
+            if "Ticker" in df.columns:
+                df = df[df["Ticker"].notna()]
             return df[COLUMNS]
         except Exception as e:
             print(f"Error reading {filepath}: {e}")

--- a/tests/test_group_analysis.py
+++ b/tests/test_group_analysis.py
@@ -59,3 +59,11 @@ def test_choose_group_empty(monkeypatch):
     monkeypatch.setattr("builtins.input", lambda *_: next(inputs))
     assert ga.choose_group(df) == "GroupX"
 
+
+def test_load_groups_directus_all_na(monkeypatch):
+    monkeypatch.setattr(ga, "USE_DIRECTUS", True)
+    monkeypatch.setattr(ga, "fetch_items", lambda c: [{"id": 1, "group": None, "ticker": None}])
+    df = ga.load_groups("dummy.xlsx")
+    assert df.empty
+    assert list(df.columns) == ga.COLUMNS
+

--- a/tests/test_portfolio_manager.py
+++ b/tests/test_portfolio_manager.py
@@ -70,3 +70,14 @@ def test_add_ticker_to_all_na_column(monkeypatch):
     monkeypatch.setattr("builtins.input", lambda *_: next(inputs))
     result = pm.add_tickers(df)
     assert "MSFT" in result["Ticker"].dropna().tolist()
+
+
+def test_load_portfolio_directus_all_na(monkeypatch):
+    monkeypatch.setattr(pm, "USE_DIRECTUS", True)
+    # Directus returns a blank record with all fields null
+    monkeypatch.setattr(
+        pm, "fetch_items", lambda c: [{"id": 1, "ticker_symbol": None, "company_name": None}]
+    )
+    df = pm.load_portfolio("dummy")
+    assert df.empty
+    assert list(df.columns) == pm.COLUMNS


### PR DESCRIPTION
## Summary
- map Directus fields back to portfolio columns
- map Directus fields back to group columns
- drop blank Directus rows when loading
- test loading of empty records from Directus

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684169b5556c8327a3d463486217b856