### PR TITLE
Improve CLI cancellations

### DIFF
--- a/UI_IMPROVEMENT_REPORT.md
+++ b/UI_IMPROVEMENT_REPORT.md
@@ -91,3 +91,8 @@ These changes ensure consistent feedback across the CLI and provide clearer guid
   Enter to cancel. See `modules/generate_report/__init__.py` lines 53–63.
 - Manual ticker entry now prints "No tickers entered" when blank to clarify the
   cancellation path. See lines 31–38 of the same file.
+
+### Recent Improvements
+- Added `input_or_cancel` helper in `modules/interface.py` at lines 30-32 to standardize prompts.
+- Updated `modules/management/directus_tools/directus_wizard.py` lines 50-93 to use this helper and print "Canceled." when input is empty.
+

--- a/modules/interface.py
+++ b/modules/interface.py
@@ -25,3 +25,8 @@ def print_table(df: pd.DataFrame, *, showindex: bool = False) -> None:
 def print_invalid_choice() -> None:
     """Standard message for invalid menu selections."""
     print(INVALID_CHOICE_MSG)
+
+
+def input_or_cancel(prompt: str) -> str:
+    """Return user input or an empty string if canceled."""
+    return input(f"{prompt} (or press Enter to cancel): ").strip()

--- a/modules/management/directus_tools/directus_wizard.py
+++ b/modules/management/directus_tools/directus_wizard.py
@@ -1,6 +1,10 @@
 import json
 
-from modules.interface import print_invalid_choice, print_header
+from modules.interface import (
+    print_invalid_choice,
+    print_header,
+    input_or_cancel,
+)
 
 from modules.data import directus_client as dc, prepare_records, refresh_field_map
 
@@ -43,36 +47,50 @@ def run_directus_wizard() -> None:
             for c in cols:
                 print(f"  - {c}")
         elif choice == "2":
-            col = input("Collection name: ").strip()
-            if col:
+            col = input_or_cancel("Collection name")
+            if not col:
+                print("Canceled.\n")
+            else:
                 fields = dc.list_fields(col)
                 print(f"Fields for '{col}':")
                 for f in fields:
                     print(f"  - {f}")
         elif choice == "3":
-            col = input("Collection name: ").strip()
-            field = input("New field name: ").strip()
-            ftype = input("Field type [string]: ").strip() or "string"
-            if col and field:
-                dc.create_field(col, field, ftype)
-                print("Field created.\n")
+            col = input_or_cancel("Collection name")
+            if not col:
+                print("Canceled.\n")
+            else:
+                field = input_or_cancel("New field name")
+                if not field:
+                    print("Canceled.\n")
+                else:
+                    ftype = input("Field type [string]: ").strip() or "string"
+                    dc.create_field(col, field, ftype)
+                    print("Field created.\n")
         elif choice == "4":
-            col = input("Collection name: ").strip()
-            if col:
+            col = input_or_cancel("Collection name")
+            if not col:
+                print("Canceled.\n")
+            else:
                 items = dc.fetch_items(col)
                 print(json.dumps(items, indent=2))
         elif choice == "5":
-            col = input("Collection name: ").strip()
-            raw = input("JSON for single item: ").strip()
-            if col and raw:
-                try:
-                    data = json.loads(raw)
-                except Exception as exc:
-                    print(f"Invalid JSON: {exc}\n")
+            col = input_or_cancel("Collection name")
+            if not col:
+                print("Canceled.\n")
+            else:
+                raw = input_or_cancel("JSON for single item")
+                if not raw:
+                    print("Canceled.\n")
                 else:
-                    records = prepare_records(col, [data])
-                    dc.insert_items(col, records)
-                    print("Item inserted.\n")
+                    try:
+                        data = json.loads(raw)
+                    except Exception as exc:
+                        print(f"Invalid JSON: {exc}\n")
+                    else:
+                        records = prepare_records(col, [data])
+                        dc.insert_items(col, records)
+                        print("Item inserted.\n")
         elif choice == "6":
             refresh_field_map()
             print("Field map updated.\n")


### PR DESCRIPTION
## Summary
- make CLI prompts consistent with `input_or_cancel`
- show cancel message in Directus wizard
- document latest changes in UI improvement log

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68417b127a0c8327a1b5478646dd375e