### PR TITLE
Add progress utilities and dashboard progress support

### DIFF
--- a/CORE_ENHANCEMENT_SUMMARY.md
+++ b/CORE_ENHANCEMENT_SUMMARY.md
@@ -112,3 +112,16 @@ from modules.utils.math_utils import percentage_change
 s = pd.Series([1, 2, 4])
 pct = percentage_change(s)
 ```
+
+## 2026 Progress utilities and dashboard improvements
+
+- **modules/utils/progress_utils.py** – new helper providing ``progress_iter`` for optional ``tqdm`` progress bars.
+- **modules/data/fetching.py** – ``fetch_basic_stock_data_batch`` now uses ``progress_iter`` for sequential progress output.
+- **modules/generate_report/excel_dashboard.py** – ``create_dashboard`` and ``create_and_open_dashboard`` accept a ``progress`` flag and use ``progress_iter`` when loading ticker data. ``_safe_concat_normal`` optimized via list comprehension.
+- **tests** – added ``test_progress_utils.py`` and a progress variant of dashboard creation.
+
+```python
+from modules.utils.progress_utils import progress_iter
+for item in progress_iter(items, description="work"):
+    do_work(item)
+```

--- a/modules/utils/__init__.py
+++ b/modules/utils/__init__.py
@@ -1,1 +1,23 @@
+"""Convenience imports for utility functions."""
 
+from .data_utils import (
+    strip_timezones,
+    ensure_period_column,
+    read_csv_if_exists,
+    read_json_if_exists,
+)
+from .excel_utils import col_to_letter, write_table
+from .math_utils import moving_average, percentage_change
+from .progress_utils import progress_iter
+
+__all__ = [
+    "strip_timezones",
+    "ensure_period_column",
+    "read_csv_if_exists",
+    "read_json_if_exists",
+    "col_to_letter",
+    "write_table",
+    "moving_average",
+    "percentage_change",
+    "progress_iter",
+]

--- a/modules/utils/progress_utils.py
+++ b/modules/utils/progress_utils.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+"""Utilities for optional progress indicators."""
+
+from typing import Iterable, Iterator, TypeVar, Optional
+
+try:
+    from tqdm import tqdm
+except Exception:  # pragma: no cover - fallback if tqdm missing
+    tqdm = None  # type: ignore
+
+T = TypeVar("T")
+
+
+def progress_iter(iterable: Iterable[T], *, description: Optional[str] = None) -> Iterator[T]:
+    """Yield items from ``iterable`` while displaying a progress bar if possible.
+
+    Parameters
+    ----------
+    iterable:
+        Any iterable sequence of values.
+    description:
+        Optional label shown alongside the progress bar.
+
+    Returns
+    -------
+    Iterator[T]
+        Iterator over the original values.
+    """
+    if tqdm is None:
+        for item in iterable:
+            yield item
+    else:  # pragma: no cover - UI behavior not tested
+        for item in tqdm(iterable, desc=description):
+            yield item

--- a/tests/test_excel_dashboard_extra.py
+++ b/tests/test_excel_dashboard_extra.py
@@ -1,5 +1,9 @@
 import pytest
-from modules.generate_report.excel_dashboard import create_dashboard, show_dashboard_in_excel
+import pandas as pd
+from modules.generate_report.excel_dashboard import (
+    create_dashboard,
+    show_dashboard_in_excel,
+)
 
 
 def test_create_dashboard_missing_folder(tmp_path):
@@ -12,3 +16,13 @@ def test_show_dashboard_in_excel_missing_file(tmp_path):
     path = tmp_path / "dash.xlsx"
     with pytest.raises(FileNotFoundError):
         show_dashboard_in_excel(path)
+
+def test_create_dashboard_with_progress(tmp_path):
+    ticker_dir = tmp_path / "AAA"
+    ticker_dir.mkdir()
+    pd.DataFrame({"symbol": ["AAA"]}).to_csv(ticker_dir / "profile.csv", index=False)
+    pd.DataFrame({"Date": pd.date_range("2023-01-01", periods=1)}).to_csv(
+        ticker_dir / "1mo_prices.csv", index=False
+    )
+    path = create_dashboard(output_root=str(tmp_path), progress=True)
+    assert path.is_file()

--- a/tests/test_progress_utils.py
+++ b/tests/test_progress_utils.py
@@ -1,0 +1,7 @@
+from modules.utils.progress_utils import progress_iter
+
+
+def test_progress_iter_basic():
+    values = [1, 2, 3]
+    result = list(progress_iter(values, description="test"))
+    assert result == values


### PR DESCRIPTION
## Summary
- add `progress_iter` helper for optional tqdm progress bars
- use `progress_iter` in `fetch_basic_stock_data_batch`
- allow progress bars when creating Excel dashboards
- optimize `_safe_concat_normal`
- add tests for new progress utilities
- document new progress features in summary

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68417b19f54883279064d7a5bdc11d86