### PR TITLE
Fix lint errors and document test results

### DIFF
--- a/BUG_AUDIT_REPORT.md
+++ b/BUG_AUDIT_REPORT.md
@@ -18,6 +18,12 @@
 - **tests/test_fetching.py** – Added test ensuring FMP requests include timeout.
 - **tests/test_fallback_data.py** – Updated mocks to accept timeout argument.
 - **tests/test_metadata_checker.py** – Updated mocks to accept timeout argument.
+- **modules/data/directus_mapper.py** – Added `TYPE_CHECKING` import and optional
+  pandas import for type hints, fixing flake8 undefined-name warning.
+- **scripts/main.py** – Removed unused `logging` import.
+- **scripts/sync_directus_fields.py** – Dropped unused `json` import and retained
+  `MAP_FILE` export for tests.
+- **tests/test_sync_directus_fields.py** – Removed unused `Path` import.
 
 ## Remaining Warnings/TODOs
 - No outstanding warnings.

--- a/agent.md
+++ b/agent.md
@@ -36,3 +36,41 @@ Provide concise commit messages and include PR summaries referencing relevant li
 ..................................                                       [100%]
 106 passed in 2.56s
 ```
+
+## Recent Findings
+
+```
+........................................................................ [ 67%]
+..................................                                       [100%]
+106 passed in 2.56s
+```
+
+## Recent Findings
+
+```
+........................................................................ [ 63%]
+..........................................                               [100%]
+=============================== warnings summary ===============================
+tests/test_portfolio_manager.py::test_add_new_ticker_with_nas_present
+tests/test_portfolio_manager.py::test_add_ticker_to_all_na_column
+  /workspace/Fundalyze/modules/management/portfolio_manager/portfolio_manager.py:266: FutureWarning: The behavior of DataFrame concatenation with empty or all-NA entries is deprecated. In a future version, this will no longer exclude empty or all-NA columns when determining the result dtypes. To retain the old behavior, exclude the relevant entries before the concat operation.
+    portfolio = pd.concat([portfolio, new_row], ignore_index=True)
+
+-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
+114 passed, 2 warnings in 2.62s
+```
+
+## Recent Findings
+
+```
+........................................................................ [ 63%]
+..........................................                               [100%]
+=============================== warnings summary ===============================
+tests/test_portfolio_manager.py::test_add_new_ticker_with_nas_present
+tests/test_portfolio_manager.py::test_add_ticker_to_all_na_column
+  /workspace/Fundalyze/modules/management/portfolio_manager/portfolio_manager.py:266: FutureWarning: The behavior of DataFrame concatenation with empty or all-NA entries is deprecated. In a future version, this will no longer exclude empty or all-NA columns when determining the result dtypes. To retain the old behavior, exclude the relevant entries before the concat operation.
+    portfolio = pd.concat([portfolio, new_row], ignore_index=True)
+
+-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
+114 passed, 2 warnings in 3.84s
+```

--- a/modules/data/directus_mapper.py
+++ b/modules/data/directus_mapper.py
@@ -1,9 +1,12 @@
 import json
 import logging
 from pathlib import Path
-from typing import Iterable, Dict, Any, List
+from typing import Iterable, Dict, Any, List, TYPE_CHECKING
 
 from .directus_client import list_fields_with_types, list_collections, list_fields
+
+if TYPE_CHECKING:  # pragma: no cover - for type hints only
+    import pandas as pd
 
 logger = logging.getLogger(__name__)
 

--- a/scripts/main.py
+++ b/scripts/main.py
@@ -10,7 +10,6 @@ import os
 import argparse
 import textwrap
 import subprocess
-import logging
 
 # Add the repository root to sys.path so 'modules' can be imported when this
 # script is executed directly via `python scripts/main.py`.

--- a/scripts/sync_directus_fields.py
+++ b/scripts/sync_directus_fields.py
@@ -2,14 +2,13 @@
 """Synchronize Directus field mappings with an interactive CLI."""
 from __future__ import annotations
 
-import json
 from typing import Any, Dict, List
 
 from modules.data.directus_client import (
     list_collections,
     list_fields_with_types,
 )
-from modules.data.directus_mapper import load_field_map, save_field_map, MAP_FILE
+from modules.data.directus_mapper import load_field_map, save_field_map, MAP_FILE  # noqa: F401
 
 
 def prompt_user(question: str, options: List[str]) -> str:

--- a/tests/test_sync_directus_fields.py
+++ b/tests/test_sync_directus_fields.py
@@ -1,6 +1,5 @@
 import importlib
 import json
-from pathlib import Path
 
 import modules.data.directus_mapper as dm
 


### PR DESCRIPTION
## Summary
- fix flake8 undefined-name warning in `directus_mapper`
- remove unused imports in CLI scripts and tests
- keep `MAP_FILE` export while silencing linter
- update bug audit report
- record latest test results in `agent.md`

## Testing
- `pytest -q -W once`


------
https://chatgpt.com/codex/tasks/task_e_68417b2015948327a31579958631353b