### PR TITLE
Map Ticker/Name to new Directus fields

### DIFF
--- a/config/directus_field_map.json
+++ b/config/directus_field_map.json
@@ -4,11 +4,11 @@
       "fields": {
         "Ticker": {
           "type": null,
-          "mapped_to": "ticker_symbol"
+          "mapped_to": "ticker"
         },
         "Name": {
           "type": null,
-          "mapped_to": "company_name"
+          "mapped_to": "name"
         },
         "Sector": {
           "type": null,
@@ -4016,11 +4016,11 @@
       "fields": {
         "Ticker": {
           "type": null,
-          "mapped_to": "ticker_symbol"
+          "mapped_to": "ticker"
         },
         "Name": {
           "type": null,
-          "mapped_to": "company_name"
+          "mapped_to": "name"
         },
         "Sector": {
           "type": null,

--- a/modules/management/portfolio_manager/portfolio_manager.py
+++ b/modules/management/portfolio_manager/portfolio_manager.py
@@ -45,7 +45,9 @@ COLUMNS = [
 
 # Mapping of Directus field names to our dataframe columns when reading
 FROM_DIRECTUS = {
+    "ticker": "Ticker",
     "ticker_symbol": "Ticker",
+    "name": "Name",
     "company_name": "Name",
     "sector": "Sector",
     "industry": "Industry",

--- a/tests/test_directus_mapper.py
+++ b/tests/test_directus_mapper.py
@@ -13,8 +13,8 @@ def test_prepare_records(monkeypatch, tmp_path):
         "collections": {
             "companies": {
                 "fields": {
-                    "Ticker": {"type": "string", "mapped_to": "ticker_symbol"},
-                    "Name": {"type": "string", "mapped_to": "company_name"},
+                    "Ticker": {"type": "string", "mapped_to": "ticker"},
+                    "Name": {"type": "string", "mapped_to": "name"},
                 }
             }
         }
@@ -22,11 +22,11 @@ def test_prepare_records(monkeypatch, tmp_path):
     file = tmp_path / "directus_field_map.json"
     file.write_text(json.dumps(mapping))
     monkeypatch.setattr(dm, "MAP_FILE", file)
-    monkeypatch.setattr(dm, "list_fields", lambda c: ["ticker_symbol", "company_name"])
+    monkeypatch.setattr(dm, "list_fields", lambda c: ["ticker", "name"])
 
     records = [{"Ticker": "AAA", "Name": "Acme", "Extra": 1}]
     prepared = dm.prepare_records("companies", records)
-    assert prepared == [{"ticker_symbol": "AAA", "company_name": "Acme"}]
+    assert prepared == [{"ticker": "AAA", "name": "Acme"}]
 
 
 def test_interactive_prepare_records(monkeypatch, tmp_path):

--- a/tests/test_portfolio_manager.py
+++ b/tests/test_portfolio_manager.py
@@ -76,7 +76,7 @@ def test_load_portfolio_directus_all_na(monkeypatch):
     monkeypatch.setattr(pm, "USE_DIRECTUS", True)
     # Directus returns a blank record with all fields null
     monkeypatch.setattr(
-        pm, "fetch_items", lambda c: [{"id": 1, "ticker_symbol": None, "company_name": None}]
+        pm, "fetch_items", lambda c: [{"id": 1, "ticker": None, "name": None}]
     )
     df = pm.load_portfolio("dummy")
     assert df.empty


### PR DESCRIPTION
## Summary
- map portfolio `Ticker` and `Name` columns to new `ticker` and `name` fields in `directus_field_map.json`
- accept new field names when loading a portfolio from Directus
- update Directus mapper tests for revised mapping
- adjust portfolio manager test for new Directus fields

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68418b2b8fe48327990a15788a4cbfc8