### PR TITLE
Add Cloudflare Access support

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -15,6 +15,8 @@ OPENBB_TOKEN=your-openbb-key
 FMP_API_KEY=your-fmp-key
 DIRECTUS_URL=https://your-directus.example.com
 DIRECTUS_TOKEN=secret-token
+CF_ACCESS_CLIENT_ID=your-client-id
+CF_ACCESS_CLIENT_SECRET=your-client-secret
 
 # Optional collection names
 DIRECTUS_PORTFOLIO_COLLECTION=portfolio
@@ -27,6 +29,9 @@ and sign up for an account. Once acquired, run the **OpenBB API Token** wizard
 inside the Settings Manager to store the token. The Settings Manager also
  provides wizards for configuring your **Directus connection** and **Notes
  directory**. Another wizard sets the **Output Directory** used for reports.
+ A **Cloudflare Access** wizard stores the `CF_ACCESS_CLIENT_ID` and
+ `CF_ACCESS_CLIENT_SECRET` variables required when your Directus instance is
+ protected by Cloudflare Access.
  Similarly, obtain a Financial Modeling Prep key from
  [fmp](https://financialmodelingprep.com/) and run the **FMP API Key** wizard
  to store it in `.env`. If you already exported these variables in your shell,

--- a/modules/data/directus_client.py
+++ b/modules/data/directus_client.py
@@ -10,6 +10,8 @@ load_settings()  # ensure .env is read when this module is imported
 DIRECTUS_URL = os.getenv("DIRECTUS_URL", "http://localhost:8055")
 # Support legacy DIRECTUS_TOKEN as well as DIRECTUS_API_TOKEN
 DIRECTUS_TOKEN = os.getenv("DIRECTUS_API_TOKEN") or os.getenv("DIRECTUS_TOKEN")
+CF_ACCESS_CLIENT_ID = os.getenv("CF_ACCESS_CLIENT_ID")
+CF_ACCESS_CLIENT_SECRET = os.getenv("CF_ACCESS_CLIENT_SECRET")
 
 logger = logging.getLogger(__name__)
 
@@ -17,16 +19,23 @@ logger = logging.getLogger(__name__)
 def reload_env() -> None:
     """Reload Directus environment variables from ``config/.env``."""
     load_settings()  # ensures .env is loaded
-    global DIRECTUS_URL, DIRECTUS_TOKEN
+    global DIRECTUS_URL, DIRECTUS_TOKEN, CF_ACCESS_CLIENT_ID, CF_ACCESS_CLIENT_SECRET
     DIRECTUS_URL = os.getenv("DIRECTUS_URL", "http://localhost:8055")
     DIRECTUS_TOKEN = os.getenv("DIRECTUS_API_TOKEN") or os.getenv("DIRECTUS_TOKEN")
+    CF_ACCESS_CLIENT_ID = os.getenv("CF_ACCESS_CLIENT_ID")
+    CF_ACCESS_CLIENT_SECRET = os.getenv("CF_ACCESS_CLIENT_SECRET")
 
 
 def _headers():
-    """Return authorization header dict if a token is configured."""
+    """Return headers including auth and Cloudflare Access credentials."""
+    headers = {}
     if DIRECTUS_TOKEN:
-        return {"Authorization": f"Bearer {DIRECTUS_TOKEN}"}
-    return {}
+        headers["Authorization"] = f"Bearer {DIRECTUS_TOKEN}"
+    if CF_ACCESS_CLIENT_ID:
+        headers["CF-Access-Client-Id"] = CF_ACCESS_CLIENT_ID
+    if CF_ACCESS_CLIENT_SECRET:
+        headers["CF-Access-Client-Secret"] = CF_ACCESS_CLIENT_SECRET
+    return headers
 
 
 def directus_request(method: str, path: str, **kwargs) -> Dict[str, Any] | None:

--- a/modules/management/group_analysis/group_analysis.py
+++ b/modules/management/group_analysis/group_analysis.py
@@ -30,9 +30,8 @@ from modules.interface import print_table, print_invalid_choice, print_header
 SETTINGS = load_settings()
 
 import pandas as pd
-import requests
 from modules.data.term_mapper import resolve_term
-from modules.data.directus_client import fetch_items, insert_items
+from modules.data.directus_client import fetch_items, insert_items, directus_request
 from modules.data import prepare_records
 
 PORTFOLIO_FILE = "portfolio.xlsx"
@@ -147,18 +146,15 @@ def save_groups(df: pd.DataFrame, filepath: str):
     token = os.getenv("DIRECTUS_TOKEN")
     if api_url and token:
         try:
-            url = f"{api_url.rstrip('/')}/items/groups"
-            headers = {"Authorization": f"Bearer {token}"}
             records = df.to_dict(orient="records")
-            resp = requests.post(
-                url,
+            resp = directus_request(
+                "POST",
+                "items/groups",
                 json=records,
-                headers=headers,
                 params={"upsert": "Ticker"},
-                timeout=10,
             )
-            if resp.status_code >= 300:
-                print(f"Warning syncing groups to Directus: {resp.status_code} {resp.text}")
+            if resp is None:
+                print("Warning syncing groups to Directus: request failed")
             else:
                 print("→ Synced groups to Directus.\n")
         except Exception as e:

--- a/modules/management/settings_manager/wizards/cf_access.py
+++ b/modules/management/settings_manager/wizards/cf_access.py
@@ -1,0 +1,22 @@
+"""Wizard to configure Cloudflare Access credentials for Directus."""
+
+from modules.config_utils import load_env, save_env
+
+LABEL = "Cloudflare Access"
+
+
+def run_wizard() -> None:
+    print("\n=== Cloudflare Access Setup ===")
+    env = load_env()
+    current_id = env.get("CF_ACCESS_CLIENT_ID", "")
+    current_secret = env.get("CF_ACCESS_CLIENT_SECRET", "")
+    client_id = input(f"CF-Access-Client-Id [{current_id}]: ").strip() or current_id
+    client_secret = (
+        input(f"CF-Access-Client-Secret [{current_secret}]: ").strip() or current_secret
+    )
+    if client_id:
+        env["CF_ACCESS_CLIENT_ID"] = client_id
+    if client_secret:
+        env["CF_ACCESS_CLIENT_SECRET"] = client_secret
+    save_env(env)
+    print("Cloudflare credentials saved to config/.env.\n")

--- a/modules/management/settings_manager/wizards/quick_setup.py
+++ b/modules/management/settings_manager/wizards/quick_setup.py
@@ -21,6 +21,8 @@ def run_wizard() -> None:
         "DIRECTUS_TOKEN",
         "DIRECTUS_PORTFOLIO_COLLECTION",
         "DIRECTUS_GROUPS_COLLECTION",
+        "CF_ACCESS_CLIENT_ID",
+        "CF_ACCESS_CLIENT_SECRET",
     ]
 
     found = False

--- a/tests/test_directus_client.py
+++ b/tests/test_directus_client.py
@@ -4,12 +4,37 @@ import modules.data.directus_client as dc
 
 def test_headers_with_token(monkeypatch):
     monkeypatch.setattr(dc, "DIRECTUS_TOKEN", "abc")
+    monkeypatch.setattr(dc, "CF_ACCESS_CLIENT_ID", None)
+    monkeypatch.setattr(dc, "CF_ACCESS_CLIENT_SECRET", None)
     assert dc._headers() == {"Authorization": "Bearer abc"}
 
 
 def test_headers_no_token(monkeypatch):
     monkeypatch.setattr(dc, "DIRECTUS_TOKEN", None)
+    monkeypatch.setattr(dc, "CF_ACCESS_CLIENT_ID", None)
+    monkeypatch.setattr(dc, "CF_ACCESS_CLIENT_SECRET", None)
     assert dc._headers() == {}
+
+
+def test_headers_cf_only(monkeypatch):
+    monkeypatch.setattr(dc, "DIRECTUS_TOKEN", None)
+    monkeypatch.setattr(dc, "CF_ACCESS_CLIENT_ID", "id")
+    monkeypatch.setattr(dc, "CF_ACCESS_CLIENT_SECRET", "secret")
+    assert dc._headers() == {
+        "CF-Access-Client-Id": "id",
+        "CF-Access-Client-Secret": "secret",
+    }
+
+
+def test_headers_token_and_cf(monkeypatch):
+    monkeypatch.setattr(dc, "DIRECTUS_TOKEN", "abc")
+    monkeypatch.setattr(dc, "CF_ACCESS_CLIENT_ID", "id")
+    monkeypatch.setattr(dc, "CF_ACCESS_CLIENT_SECRET", "secret")
+    assert dc._headers() == {
+        "Authorization": "Bearer abc",
+        "CF-Access-Client-Id": "id",
+        "CF-Access-Client-Secret": "secret",
+    }
 
 
 def test_list_fields(monkeypatch):


### PR DESCRIPTION
## Summary
- support CF_ACCESS_CLIENT_ID and CF_ACCESS_CLIENT_SECRET headers for Directus API
- sync portfolio/groups to Directus using directus_request so new headers work
- add Cloudflare Access wizard and integrate with quick setup
- document new environment variables and wizard
- test header generation with Cloudflare credentials

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841989e37d883278b1c8d8b0c01e348