### PR TITLE
Improve CLI UX and fix report generator

### DIFF
--- a/UI_IMPROVEMENT_REPORT.md
+++ b/UI_IMPROVEMENT_REPORT.md
@@ -102,3 +102,10 @@ These changes ensure consistent feedback across the CLI and provide clearer guid
 - Improved settings menus to use `print_menu` and added cancel options for delete prompts (lines 116-145 & 196-206 of settings_manager).
 - New helper imported throughout modules ensures consistent numbering across screens.
 
+
+### New CLI Enhancements
+- Standardized all feature-specific menus to use `print_menu` for numbering consistency.
+- Added `print_menu` imports and refactored menus in `portfolio_manager.py`, `group_analysis.py`, `note_manager.py`, and `directus_wizard.py`.
+- Converted the report ticker selection menu to use `print_menu` (see `modules/generate_report/__init__.py` lines 24-34).
+- Fixed stray text in `report_generator.py` that caused an `IndentationError`.
+

--- a/agent.md
+++ b/agent.md
@@ -1,0 +1,187 @@
+
+## Recent Findings
+
+```
+
+==================================== ERRORS ====================================
+______________________ ERROR collecting tests/test_e2e.py ______________________
+/root/.pyenv/versions/3.11.12/lib/python3.11/site-packages/_pytest/python.py:497: in importtestmodule
+    mod = import_path(
+/root/.pyenv/versions/3.11.12/lib/python3.11/site-packages/_pytest/pathlib.py:587: in import_path
+    importlib.import_module(module_name)
+/root/.pyenv/versions/3.11.12/lib/python3.11/importlib/__init__.py:126: in import_module
+    return _bootstrap._gcd_import(name[level:], package, level)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+<frozen importlib._bootstrap>:1204: in _gcd_import
+    ???
+<frozen importlib._bootstrap>:1176: in _find_and_load
+    ???
+<frozen importlib._bootstrap>:1147: in _find_and_load_unlocked
+    ???
+<frozen importlib._bootstrap>:690: in _load_unlocked
+    ???
+/root/.pyenv/versions/3.11.12/lib/python3.11/site-packages/_pytest/assertion/rewrite.py:186: in exec_module
+    exec(co, module.__dict__)
+tests/test_e2e.py:4: in <module>
+    import modules.generate_report.report_generator as rg
+modules/generate_report/__init__.py:3: in <module>
+    from .report_generator import fetch_and_compile
+E     File "/workspace/Fundalyze/modules/generate_report/report_generator.py", line 58
+E       codex/audit-and-remediate-bugs-in-codebase
+E                                                 ^
+E   IndentationError: unindent does not match any outer indentation level
+________________ ERROR collecting tests/test_excel_dashboard.py ________________
+/root/.pyenv/versions/3.11.12/lib/python3.11/site-packages/_pytest/python.py:497: in importtestmodule
+    mod = import_path(
+/root/.pyenv/versions/3.11.12/lib/python3.11/site-packages/_pytest/pathlib.py:587: in import_path
+    importlib.import_module(module_name)
+/root/.pyenv/versions/3.11.12/lib/python3.11/importlib/__init__.py:126: in import_module
+    return _bootstrap._gcd_import(name[level:], package, level)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+<frozen importlib._bootstrap>:1204: in _gcd_import
+    ???
+<frozen importlib._bootstrap>:1176: in _find_and_load
+    ???
+<frozen importlib._bootstrap>:1147: in _find_and_load_unlocked
+    ???
+<frozen importlib._bootstrap>:690: in _load_unlocked
+    ???
+/root/.pyenv/versions/3.11.12/lib/python3.11/site-packages/_pytest/assertion/rewrite.py:186: in exec_module
+    exec(co, module.__dict__)
+tests/test_excel_dashboard.py:3: in <module>
+    from generate_report.excel_dashboard import (
+modules/generate_report/__init__.py:3: in <module>
+    from .report_generator import fetch_and_compile
+E     File "/workspace/Fundalyze/modules/generate_report/report_generator.py", line 58
+E       codex/audit-and-remediate-bugs-in-codebase
+E                                                 ^
+E   IndentationError: unindent does not match any outer indentation level
+_____________ ERROR collecting tests/test_excel_dashboard_extra.py _____________
+/root/.pyenv/versions/3.11.12/lib/python3.11/site-packages/_pytest/python.py:497: in importtestmodule
+    mod = import_path(
+/root/.pyenv/versions/3.11.12/lib/python3.11/site-packages/_pytest/pathlib.py:587: in import_path
+    importlib.import_module(module_name)
+/root/.pyenv/versions/3.11.12/lib/python3.11/importlib/__init__.py:126: in import_module
+    return _bootstrap._gcd_import(name[level:], package, level)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+<frozen importlib._bootstrap>:1204: in _gcd_import
+    ???
+<frozen importlib._bootstrap>:1176: in _find_and_load
+    ???
+<frozen importlib._bootstrap>:1147: in _find_and_load_unlocked
+    ???
+<frozen importlib._bootstrap>:690: in _load_unlocked
+    ???
+/root/.pyenv/versions/3.11.12/lib/python3.11/site-packages/_pytest/assertion/rewrite.py:186: in exec_module
+    exec(co, module.__dict__)
+tests/test_excel_dashboard_extra.py:3: in <module>
+    from modules.generate_report.excel_dashboard import (
+modules/generate_report/__init__.py:3: in <module>
+    from .report_generator import fetch_and_compile
+E     File "/workspace/Fundalyze/modules/generate_report/report_generator.py", line 58
+E       codex/audit-and-remediate-bugs-in-codebase
+E                                                 ^
+E   IndentationError: unindent does not match any outer indentation level
+_________________ ERROR collecting tests/test_fallback_data.py _________________
+/root/.pyenv/versions/3.11.12/lib/python3.11/site-packages/_pytest/python.py:497: in importtestmodule
+    mod = import_path(
+/root/.pyenv/versions/3.11.12/lib/python3.11/site-packages/_pytest/pathlib.py:587: in import_path
+    importlib.import_module(module_name)
+/root/.pyenv/versions/3.11.12/lib/python3.11/importlib/__init__.py:126: in import_module
+    return _bootstrap._gcd_import(name[level:], package, level)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+<frozen importlib._bootstrap>:1204: in _gcd_import
+    ???
+<frozen importlib._bootstrap>:1176: in _find_and_load
+    ???
+<frozen importlib._bootstrap>:1147: in _find_and_load_unlocked
+    ???
+<frozen importlib._bootstrap>:690: in _load_unlocked
+    ???
+/root/.pyenv/versions/3.11.12/lib/python3.11/site-packages/_pytest/assertion/rewrite.py:186: in exec_module
+    exec(co, module.__dict__)
+tests/test_fallback_data.py:5: in <module>
+    import modules.generate_report.fallback_data as fb
+modules/generate_report/__init__.py:3: in <module>
+    from .report_generator import fetch_and_compile
+E     File "/workspace/Fundalyze/modules/generate_report/report_generator.py", line 58
+E       codex/audit-and-remediate-bugs-in-codebase
+E                                                 ^
+E   IndentationError: unindent does not match any outer indentation level
+_______________ ERROR collecting tests/test_metadata_checker.py ________________
+/root/.pyenv/versions/3.11.12/lib/python3.11/site-packages/_pytest/python.py:497: in importtestmodule
+    mod = import_path(
+/root/.pyenv/versions/3.11.12/lib/python3.11/site-packages/_pytest/pathlib.py:587: in import_path
+    importlib.import_module(module_name)
+/root/.pyenv/versions/3.11.12/lib/python3.11/importlib/__init__.py:126: in import_module
+    return _bootstrap._gcd_import(name[level:], package, level)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+<frozen importlib._bootstrap>:1204: in _gcd_import
+    ???
+<frozen importlib._bootstrap>:1176: in _find_and_load
+    ???
+<frozen importlib._bootstrap>:1147: in _find_and_load_unlocked
+    ???
+<frozen importlib._bootstrap>:690: in _load_unlocked
+    ???
+/root/.pyenv/versions/3.11.12/lib/python3.11/site-packages/_pytest/assertion/rewrite.py:186: in exec_module
+    exec(co, module.__dict__)
+tests/test_metadata_checker.py:5: in <module>
+    import modules.generate_report.metadata_checker as mc
+modules/generate_report/__init__.py:3: in <module>
+    from .report_generator import fetch_and_compile
+E     File "/workspace/Fundalyze/modules/generate_report/report_generator.py", line 58
+E       codex/audit-and-remediate-bugs-in-codebase
+E                                                 ^
+E   IndentationError: unindent does not match any outer indentation level
+________________ ERROR collecting tests/test_output_dir_env.py _________________
+/root/.pyenv/versions/3.11.12/lib/python3.11/site-packages/_pytest/python.py:497: in importtestmodule
+    mod = import_path(
+/root/.pyenv/versions/3.11.12/lib/python3.11/site-packages/_pytest/pathlib.py:587: in import_path
+    importlib.import_module(module_name)
+/root/.pyenv/versions/3.11.12/lib/python3.11/importlib/__init__.py:126: in import_module
+    return _bootstrap._gcd_import(name[level:], package, level)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+<frozen importlib._bootstrap>:1204: in _gcd_import
+    ???
+<frozen importlib._bootstrap>:1176: in _find_and_load
+    ???
+<frozen importlib._bootstrap>:1147: in _find_and_load_unlocked
+    ???
+<frozen importlib._bootstrap>:690: in _load_unlocked
+    ???
+/root/.pyenv/versions/3.11.12/lib/python3.11/site-packages/_pytest/assertion/rewrite.py:186: in exec_module
+    exec(co, module.__dict__)
+tests/test_output_dir_env.py:3: in <module>
+    import modules.generate_report.report_generator as rg
+modules/generate_report/__init__.py:3: in <module>
+    from .report_generator import fetch_and_compile
+E     File "/workspace/Fundalyze/modules/generate_report/report_generator.py", line 58
+E       codex/audit-and-remediate-bugs-in-codebase
+E                                                 ^
+E   IndentationError: unindent does not match any outer indentation level
+=========================== short test summary info ============================
+ERROR tests/test_e2e.py
+ERROR tests/test_excel_dashboard.py
+ERROR tests/test_excel_dashboard_extra.py
+ERROR tests/test_fallback_data.py
+ERROR tests/test_metadata_checker.py
+ERROR tests/test_output_dir_env.py
+!!!!!!!!!!!!!!!!!!! Interrupted: 6 errors during collection !!!!!!!!!!!!!!!!!!!!
+6 errors in 2.85s
+```
+
+## Recent Findings
+
+```
+........................................................................ [ 61%]
+..............................................                           [100%]
+=============================== warnings summary ===============================
+tests/test_portfolio_manager.py::test_add_new_ticker_with_nas_present
+tests/test_portfolio_manager.py::test_add_ticker_to_all_na_column
+  /workspace/Fundalyze/modules/management/portfolio_manager/portfolio_manager.py:273: FutureWarning: The behavior of DataFrame concatenation with empty or all-NA entries is deprecated. In a future version, this will no longer exclude empty or all-NA columns when determining the result dtypes. To retain the old behavior, exclude the relevant entries before the concat operation.
+    portfolio = pd.concat([portfolio, new_row], ignore_index=True)
+
+-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
+118 passed, 2 warnings in 12.49s
+```

--- a/modules/generate_report/__init__.py
+++ b/modules/generate_report/__init__.py
@@ -16,17 +16,20 @@ from modules.management.group_analysis.group_analysis import (
     load_groups,
     GROUPS_FILE,
 )
-from modules.interface import print_invalid_choice, print_header
+from modules.interface import print_invalid_choice, print_header, print_menu
 
 
 def _select_tickers() -> list[str]:
     """Prompt user to choose tickers manually, from portfolio or a group."""
     print_header("📑 Reports")
-    print("1) Enter ticker symbols manually")
-    print("2) Use all tickers from portfolio")
-    print("3) Choose a group")
-    print("4) Return to Main Menu")
-    choice = input("Select an option [1-4]: ").strip()
+    options = [
+        "Enter ticker symbols manually",
+        "Use all tickers from portfolio",
+        "Choose a group",
+        "Return to Main Menu",
+    ]
+    print_menu(options)
+    choice = input(f"Select an option [1-{len(options)}]: ").strip()
 
     if choice == "1":
         raw = input(

--- a/modules/generate_report/report_generator.py
+++ b/modules/generate_report/report_generator.py
@@ -55,7 +55,6 @@ def fetch_and_compile(
     obb_mod = _get_openbb()
 
     if local_output is None:
- codex/audit-and-remediate-bugs-in-codebase
         # If a base_output path was provided, assume the caller expects local
         # files regardless of DIRECTUS_URL. Otherwise default to uploading when
         # DIRECTUS_URL is configured.
@@ -68,7 +67,6 @@ def fetch_and_compile(
             local_output = True
         else:
             local_output = not bool(os.getenv("DIRECTUS_URL"))
- main
 
     ticker_dir = rutils.ensure_output_dir(symbol, base_output) if local_output else (base_output or ".")
     metadata = {

--- a/modules/management/directus_tools/directus_wizard.py
+++ b/modules/management/directus_tools/directus_wizard.py
@@ -4,6 +4,7 @@ from modules.interface import (
     print_invalid_choice,
     print_header,
     input_or_cancel,
+    print_menu,
 )
 
 from modules.data import directus_client as dc, prepare_records, refresh_field_map
@@ -32,14 +33,17 @@ def run_directus_wizard() -> None:
 
     while True:
         print_header("\U0001F9E9 Directus Tools")
-        print("1) List Collections")
-        print("2) View Fields in Collection")
-        print("3) Add Field to Collection")
-        print("4) Fetch Items from Collection")
-        print("5) Insert Item into Collection")
-        print("6) Refresh Field Map")
-        print("7) Return to Main Menu")
-        choice = input("Select an option [1-7]: ").strip()
+        options = [
+            "List Collections",
+            "View Fields in Collection",
+            "Add Field to Collection",
+            "Fetch Items from Collection",
+            "Insert Item into Collection",
+            "Refresh Field Map",
+            "Return to Main Menu",
+        ]
+        print_menu(options)
+        choice = input(f"Select an option [1-{len(options)}]: ").strip()
 
         if choice == "1":
             cols = dc.list_collections()

--- a/modules/management/group_analysis/group_analysis.py
+++ b/modules/management/group_analysis/group_analysis.py
@@ -25,7 +25,12 @@ import os
 
 from modules.config_utils import load_settings  # noqa: E402
 from modules.analytics import portfolio_summary
-from modules.interface import print_table, print_invalid_choice, print_header
+from modules.interface import (
+    print_table,
+    print_invalid_choice,
+    print_header,
+    print_menu,
+)
 
 SETTINGS = load_settings()
 
@@ -401,13 +406,16 @@ def main():
 
     while True:
         print("Choose an action:")
-        print("  1) View all groups")
-        print("  2) Create a new group (or link to portfolio)")
-        print("  3) Add ticker(s) to an existing group")
-        print("  4) Remove ticker from a group")
-        print("  5) Delete an entire group")
-        print("  6) Exit")
-        choice = input("Select an option [1-6]: ").strip()
+        options = [
+            "View all groups",
+            "Create a new group (or link to portfolio)",
+            "Add ticker(s) to an existing group",
+            "Remove ticker from a group",
+            "Delete an entire group",
+            "Exit",
+        ]
+        print_menu(options)
+        choice = input(f"Select an option [1-{len(options)}]: ").strip()
 
         if choice == "1":
             view_groups(groups)

--- a/modules/management/note_manager/note_manager.py
+++ b/modules/management/note_manager/note_manager.py
@@ -3,7 +3,7 @@ import re
 from pathlib import Path
 from typing import List, Optional
 
-from modules.interface import print_invalid_choice, print_header
+from modules.interface import print_invalid_choice, print_header, print_menu
 
 
 def get_notes_dir() -> Path:
@@ -61,11 +61,14 @@ def run_note_manager() -> None:
     """Interactive menu for creating and viewing notes."""
     while True:
         print_header("📝 Notes")
-        print("1) List Notes")
-        print("2) View Note")
-        print("3) Create Note")
-        print("4) Return to Main Menu")
-        choice = input("Select an option [1-4]: ").strip()
+        options = [
+            "List Notes",
+            "View Note",
+            "Create Note",
+            "Return to Main Menu",
+        ]
+        print_menu(options)
+        choice = input(f"Select an option [1-{len(options)}]: ").strip()
 
         if choice == "1":
             notes = list_notes()

--- a/modules/management/portfolio_manager/portfolio_manager.py
+++ b/modules/management/portfolio_manager/portfolio_manager.py
@@ -18,7 +18,12 @@ Description:
 import os
 
 from modules.analytics import portfolio_summary, sector_counts
-from modules.interface import print_table, print_invalid_choice, print_header
+from modules.interface import (
+    print_table,
+    print_invalid_choice,
+    print_header,
+    print_menu,
+)
 
 import pandas as pd
 from modules.data.term_mapper import resolve_term
@@ -334,12 +339,15 @@ def main():
 
     while True:
         print("Choose an action:")
-        print("  1) View portfolio")
-        print("  2) Add ticker(s)")
-        print("  3) Update ticker data")
-        print("  4) Remove ticker")
-        print("  5) Exit")
-        choice = input("Select an option [1-5]: ").strip()
+        options = [
+            "View portfolio",
+            "Add ticker(s)",
+            "Update ticker data",
+            "Remove ticker",
+            "Exit",
+        ]
+        print_menu(options)
+        choice = input(f"Select an option [1-{len(options)}]: ").strip()
 
         if choice == "1":
             view_portfolio(portfolio)

--- a/test_findings.txt
+++ b/test_findings.txt
@@ -3,8 +3,8 @@
 =============================== warnings summary ===============================
 tests/test_portfolio_manager.py::test_add_new_ticker_with_nas_present
 tests/test_portfolio_manager.py::test_add_ticker_to_all_na_column
-  /workspace/Fundalyze/modules/management/portfolio_manager/portfolio_manager.py:269: FutureWarning: The behavior of DataFrame concatenation with empty or all-NA entries is deprecated. In a future version, this will no longer exclude empty or all-NA columns when determining the result dtypes. To retain the old behavior, exclude the relevant entries before the concat operation.
+  /workspace/Fundalyze/modules/management/portfolio_manager/portfolio_manager.py:273: FutureWarning: The behavior of DataFrame concatenation with empty or all-NA entries is deprecated. In a future version, this will no longer exclude empty or all-NA columns when determining the result dtypes. To retain the old behavior, exclude the relevant entries before the concat operation.
     portfolio = pd.concat([portfolio, new_row], ignore_index=True)
 
 -- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
-118 passed, 2 warnings in 51.81s
+118 passed, 2 warnings in 12.49s


### PR DESCRIPTION
## Summary
- standardize menus across CLI modules using `print_menu`
- remove stray lines from `report_generator.py`
- fix ticker selection menu in `generate_report`
- append automated test results

## Testing
- `pytest -q -W once`

------
https://chatgpt.com/codex/tasks/task_e_6841aa1a82b88327bad5f049c3ee5941