### PR TITLE
Improve generate_report docs

### DIFF
--- a/modules/generate_report/README.md
+++ b/modules/generate_report/README.md
@@ -1,0 +1,19 @@
+# Generate Report Module
+
+This folder contains the workflow for building Fundalyze ticker reports. Each script focuses on one phase of the process:
+
+1. **`report_generator.py`** – fetch company profile, price history and financial statements using OpenBB. The results are written as CSV and aggregated into a Markdown report along with a `metadata.json` file.
+2. **`metadata_checker.py`** – scans existing metadata for entries whose `source` value starts with `ERROR`. Any failed files are re‑fetched via yfinance or FMP and the metadata updated.
+3. **`fallback_data.py`** – if data is still missing after the checker, this step performs a full yfinance fallback to repopulate all CSV files.
+4. **`excel_dashboard.py`** – converts all ticker CSVs into an Excel workbook where each sheet is an Excel Table. The workbook makes it easy to slice and analyze the results.
+
+The default output root is the `output/` directory at the project root. You can override it by setting the `OUTPUT_DIR` environment variable when running these utilities.
+
+```mermaid
+flowchart TD
+    A[fetch_and_compile] --> B[metadata_checker]
+    B --> C[fallback_data]
+    C --> D[create_dashboard]
+```
+
+Run the full lifecycle via `scripts/main.py report` or call each step individually.

--- a/modules/generate_report/__init__.py
+++ b/modules/generate_report/__init__.py
@@ -1,4 +1,12 @@
 # src/generate_report/__init__.py
+"""Convenience entry points for the report-generation workflow.
+
+The :mod:`generate_report` package orchestrates fetching data, fixing missing
+files and building an Excel dashboard.  ``fetch_and_compile`` collects the raw
+datasets and Markdown report, ``run_for_tickers`` repairs failed downloads,
+``run_fallback_data`` performs a last-resort yfinance pull, and
+``create_and_open_dashboard`` produces the final Excel workbook.
+"""
 
 from .report_generator import fetch_and_compile
 from .metadata_checker import run_for_tickers

--- a/modules/generate_report/excel_dashboard.py
+++ b/modules/generate_report/excel_dashboard.py
@@ -101,7 +101,13 @@ def _write_dashboard(
     df_cash_ann: pd.DataFrame,
     df_cash_qtr: pd.DataFrame,
 ) -> None:
-    """Write all tables to ``dash_path`` as an Excel workbook."""
+    """Write all tables to ``dash_path`` as an Excel workbook.
+
+    Each ``DataFrame`` becomes an Excel *Table* so formulas can use structured
+    references.  Sheets are only created when the corresponding DataFrame is not
+    empty.  The caller receives the path to the workbook and may open it with
+    :func:`show_dashboard_in_excel`.
+    """
     tables = [
         (df_profiles, "Profile", "Profile_Table", "Table Style Medium 2"),
         (df_prices, "PriceHistory", "PriceHistory_Table", "Table Style Medium 3"),

--- a/modules/generate_report/fallback_data.py
+++ b/modules/generate_report/fallback_data.py
@@ -1,13 +1,14 @@
 # src/generate_report/fallback_data.py
 
-"""
-fallback_data.py
+"""Final safety net for repairing ticker folders.
 
-When some CSV files (profile, price history, or financial statements) fail to fetch
-via the primary methods (OpenBB → yfinance → FMP), this module attempts a “full”
-yfinance-based fallback to repopulate all missing files for a given ticker.
+If after running :mod:`metadata_checker` some files are still missing or contain
+``ERROR`` entries, ``fallback_data.py`` performs a full yfinance download of
+profile, price history and all statements.  The freshly fetched files replace
+any incomplete ones and ``metadata.json`` is updated accordingly.
 
-Usage:
+Usage example::
+
     run_fallback_data()  # scans output/, attempts fix for each ticker folder
 """
 

--- a/modules/generate_report/metadata_checker.py
+++ b/modules/generate_report/metadata_checker.py
@@ -1,12 +1,14 @@
 #!/usr/bin/env python3
 # metadata_checker.py
 
-"""
-This script examines each metadata.json under output/<TICKER>/,
-finds any files whose 'source' field indicates an ERROR, and
-re-fetches that piece of data via yfinance (or via FMP as a fallback
-for financial statements). It then overwrites the CSV and updates
-metadata.json with new source, source_url, and fetched_at timestamp.
+"""Validate downloaded datasets and attempt targeted repairs.
+
+``metadata_checker.py`` scans each ``metadata.json`` under ``output/<TICKER>/``
+for entries whose ``source`` value begins with ``ERROR``.  Those files are
+re‑fetched using yfinance and, for financial statements, Financial Modeling
+Prep as a secondary source.  The CSV is overwritten and metadata updated with
+the new ``source`` and ``fetched_at`` timestamp.  Any remaining ``ERROR``
+entries are later handled by :mod:`fallback_data`.
 """
 
 import json

--- a/modules/generate_report/report_generator.py
+++ b/modules/generate_report/report_generator.py
@@ -1,11 +1,19 @@
-"""
-script: report_generator.py
+"""Utility for creating markdown reports from market data.
 
-Dependencies:
-    pip install openbb[all] matplotlib pandas
+``report_generator.py`` coordinates OpenBB calls to fetch a company's profile,
+price history and financial statements.  Each dataset is written to ``CSV`` and
+optionally ``JSON``.  The function then compiles a markdown summary and a
+``metadata.json`` file describing the source of every output.  The goal is to
+produce a self‑contained folder under ``output/<TICKER>/`` that can later be
+checked by :mod:`metadata_checker` and included in the Excel dashboard.
 
-Usage:
-    python src/report_generator.py AAPL MSFT GOOGL
+Dependencies
+------------
+``pip install openbb[all] matplotlib pandas``
+
+Example
+-------
+``python src/report_generator.py AAPL MSFT GOOGL``
 """
 
 from __future__ import annotations
@@ -40,6 +48,14 @@ def fetch_and_compile(
 ) -> None:
     """Generate all report files for ``symbol``.
 
+    The function orchestrates every step required to populate a ticker folder.
+    It calls helper functions from :mod:`report_utils` to fetch the profile,
+    price history and financial statements.  Markdown lines describing each
+    action are accumulated in ``lines`` and finally written to ``report.md``.
+    ``metadata.json`` is updated in parallel with details about the data source
+    or, if an error occurs, an ``ERROR`` entry which later triggers the
+    fallback utilities.
+
     Parameters
     ----------
     symbol:
@@ -58,15 +74,9 @@ def fetch_and_compile(
     obb_mod = _get_openbb()
 
     if local_output is None:
- rezv6y-codex/revamp-documentation-and-contribution-guide
-=======
- main
         # If a base_output path was provided, assume the caller expects local
         # files regardless of DIRECTUS_URL. Otherwise default to uploading when
         # DIRECTUS_URL is configured.
-=======
-
- main
         local_output = bool(base_output or os.getenv("OUTPUT_DIR")) or not bool(
             os.getenv("DIRECTUS_URL")
         )


### PR DESCRIPTION
## Summary
- document generate_report module
- expand docstrings for markdown and Excel generation logic
- clarify metadata and fallback mechanisms

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841ae00708483278a142ba54f34258f