### PR TITLE
Add documentation for data modules

### DIFF
--- a/docs/overview.md
+++ b/docs/overview.md
@@ -24,10 +24,12 @@ Importing `modules.management` exposes convenience functions such as
 directly.
 
 ### `modules.data`
-Lower-level helpers used across the app:
-- `fetching.py` – small wrappers around yfinance and HTTP calls.
+Lower-level helpers used across the app (see [modules/data/README.md](../modules/data/README.md)):
+- `fetching.py` – wrappers around yfinance with FMP fallback.
 - `directus_client.py` – optional Directus integration for remote storage.
-- `term_mapper.py` – maps common financial terms to API field names and stores the mapping in `config/term_mapping.json`.
+- `directus_mapper.py` – keeps `directus_field_map.json` in sync and prepares records for upload.
+- `term_mapper.py` – maps common financial terms to canonical names.
+- `compare.py` – compares profile data from different providers.
 
 ### `modules.utils`
 Small helper utilities reused across the codebase:

--- a/modules/data/README.md
+++ b/modules/data/README.md
@@ -1,0 +1,36 @@
+# modules.data
+
+Helpers for retrieving and normalizing data as well as communicating with a Directus instance.
+
+## Provided modules
+
+- **`fetching.py`** – wrappers around `yfinance` and the Financial Modeling Prep (FMP) API. The
+  `fetch_basic_stock_data` function tries yfinance first then falls back to FMP
+  if data is incomplete.
+- **`directus_client.py`** – thin REST client used for CRUD operations against a
+  Directus server. Credentials are read from `config/.env` and all helpers return
+  `None` on error so offline use is possible.
+- **`directus_mapper.py`** – maintains `config/directus_field_map.json` and
+  converts local DataFrame columns into the field names expected by Directus.
+  `refresh_field_map` queries the server to keep the JSON file up‑to‑date and
+  interactive helpers prompt for unmapped columns.
+- **`term_mapper.py`** – resolves sector and industry names to a canonical term
+  using a JSON map. When an unknown term is encountered the module optionally
+  suggests a mapping via OpenAI and then asks the user for confirmation.
+- **`compare.py`** – debugging utility that compares company profile data from
+  OpenBB with yfinance.
+
+## Data flow
+
+```mermaid
+flowchart LR
+    A[fetching.py] --> B(term_mapper)
+    A --> C((DataFrame))
+    C --> D(directus_mapper)
+    D --> E(directus_client)
+    E --> F[(Directus API)]
+```
+
+Fetching functions first normalize sectors and industries via `term_mapper`. The
+resulting rows can then be prepared for upload using `directus_mapper` and
+finally inserted into Directus through `directus_client` if desired.

--- a/modules/data/directus_client.py
+++ b/modules/data/directus_client.py
@@ -1,3 +1,11 @@
+"""Minimal Directus REST client used throughout Fundalyze.
+
+The module lazily reads credentials from ``config/.env`` and exposes helper
+functions for common CRUD operations. When Directus is not configured the
+wrappers simply return ``None`` so the rest of the code can continue to operate
+in a local-only mode.
+"""
+
 import os
 import logging
 import math
@@ -39,7 +47,7 @@ def reload_env() -> None:
 
 
 def _headers():
-    """Return headers including auth and Cloudflare Access credentials."""
+    """Return authentication headers for Directus requests."""
     headers = {}
     if DIRECTUS_TOKEN:
         headers["Authorization"] = f"Bearer {DIRECTUS_TOKEN}"

--- a/modules/data/directus_mapper.py
+++ b/modules/data/directus_mapper.py
@@ -1,3 +1,11 @@
+"""Utilities for mapping DataFrame columns to Directus fields.
+
+``directus_mapper`` keeps ``config/directus_field_map.json`` in sync with your
+Directus instance and helps convert records prior to upload. It relies on
+``directus_client`` to query the server and can run interactively to prompt for
+missing mappings.
+"""
+
 import json
 import logging
 from pathlib import Path

--- a/modules/data/term_mapper.py
+++ b/modules/data/term_mapper.py
@@ -1,3 +1,12 @@
+"""Canonical term resolution helpers used for sectors and industries.
+
+The mapping stored in ``config/term_mapping.json`` links a canonical term
+(``Technology``) to a list of aliases (``IT``, ``Tech``).  ``resolve_term``
+normalizes an input string and attempts to find the best match. If no mapping is
+available it optionally consults OpenAI for suggestions and finally prompts the
+user. The resulting alias is persisted for future runs.
+"""
+
 import json
 import os
 from pathlib import Path
@@ -19,6 +28,7 @@ MAPPING_FILE = PROJECT_ROOT / 'config' / 'term_mapping.json'
 
 
 def load_mapping() -> Dict[str, List[str]]:
+    """Return term mapping dictionary from :data:`MAPPING_FILE`."""
     if not MAPPING_FILE.is_file():
         return {}
     with open(MAPPING_FILE, 'r', encoding='utf-8') as f:
@@ -26,16 +36,19 @@ def load_mapping() -> Dict[str, List[str]]:
 
 
 def save_mapping(mapping: Dict[str, List[str]]):
+    """Write ``mapping`` to :data:`MAPPING_FILE`."""
     MAPPING_FILE.parent.mkdir(parents=True, exist_ok=True)
     with open(MAPPING_FILE, 'w', encoding='utf-8') as f:
         json.dump(mapping, f, indent=2)
 
 
 def _normalize(text: str) -> str:
+    """Return lowercase, trimmed representation of ``text``."""
     return text.strip().lower()
 
 
 def add_alias(canonical: str, alias: str):
+    """Persist ``alias`` as an alternative spelling for ``canonical``."""
     mapping = load_mapping()
     canonical_norm = canonical.strip()
     alias_norm = alias.strip()
@@ -49,6 +62,7 @@ def add_alias(canonical: str, alias: str):
 
 
 def _suggest_with_openai(term: str, options: List[str]) -> Optional[str]:
+    """Return best matching option suggested by OpenAI or ``None``."""
     if openai is None or not os.getenv('OPENAI_API_KEY'):
         return None
     try:
@@ -72,7 +86,12 @@ def _suggest_with_openai(term: str, options: List[str]) -> Optional[str]:
 
 
 def resolve_term(term: str) -> str:
-    """Return canonical term for given term. If unknown, ask user."""
+    """Return canonical representation for ``term``.
+
+    The function checks existing aliases, optionally queries OpenAI for a best
+    guess and finally prompts the user to pick or create a mapping. Any new
+    mapping is saved via :func:`add_alias`.
+    """
     if not term:
         return term
     mapping = load_mapping()


### PR DESCRIPTION
## Summary
- add module-level README for data helpers with mermaid diagram
- document Directus client and mapping modules via docstrings
- clarify term mapper flow and expose docs in overview

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841adf7df208327b52b543f8d5cff1b