### PR TITLE
Add management documentation and module docstrings

### DIFF
--- a/docs/management_tools.md
+++ b/docs/management_tools.md
@@ -1,0 +1,48 @@
+# Management Tools
+
+This document explains the command line utilities under `modules/management` and how to interact with them. Each tool exposes a simple menu-driven interface and can be launched either via `scripts/main.py` or by importing the appropriate function.
+
+```
+modules/management
+├── portfolio_manager/
+│   └── portfolio_manager.py
+├── group_analysis/
+│   └── group_analysis.py
+├── note_manager/
+│   └── note_manager.py
+├── settings_manager/
+│   ├── settings_manager.py
+│   └── wizards/
+│       ├── directus_setup.py
+│       ├── notes_dir.py
+│       ├── openbb_key.py
+│       ├── fmp_key.py
+│       ├── openai_key.py
+│       ├── output_dir.py
+│       ├── timezone.py
+│       ├── cf_access.py
+│       └── quick_setup.py
+└── directus_tools/
+    └── directus_wizard.py
+```
+
+## Portfolio Manager
+Launch with `run_portfolio_manager()` or directly:
+```bash
+python modules/management/portfolio_manager/portfolio_manager.py
+```
+The menu allows you to view your portfolio, add or update tickers, and remove entries. Data is stored in `portfolio.xlsx` and optionally synced with Directus if the related environment variables are configured. When adding tickers the script attempts to fetch data from yfinance and prompts for confirmation or manual entry if anything is missing.
+
+## Group Analysis
+Run via `run_group_analysis()`. Groups are stored in `groups.xlsx` and can be linked to portfolio tickers or given a custom name. You can create groups, add or remove tickers, and delete entire groups. The workflow mirrors the portfolio manager but operates on a "Group" column in the spreadsheet.
+
+## Note Manager
+`run_note_manager()` provides a minimal Markdown note system. Each note is stored as a `.md` file under the directory specified by `NOTES_DIR` (defaults to `notes/`). The CLI lets you list notes, view contents (showing any `[[wikilink]]` references) and create new notes interactively. Enter an empty title or choose "Return" to cancel an action.
+
+## Settings Manager
+Use `run_settings_manager()` to edit `config/settings.json` or `.env`. The tool exposes submenus for general settings, environment variables and setup wizards. Helper functions validate input, allow cancellation on blank entries and ensure the configuration directory exists.
+
+## Directus Tools
+`run_directus_wizard()` exposes common Directus API operations like listing collections, viewing or creating fields and inserting items. The wizard checks that `DIRECTUS_URL` and a token are configured, otherwise it offers to run the Directus setup wizard.
+
+These management utilities are intentionally lightweight so they can be extended easily. See `docs/DEVELOPER_GUIDE.md` for guidelines on adding new commands.

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -19,6 +19,9 @@ Tools for maintaining local data files:
 - `group_analysis` – manage related tickers in `groups.xlsx`.
 - `note_manager` – simple Markdown note system supporting `[[wikilinks]]`.
 
+For a walkthrough of each CLI and a diagram of the management package layout see
+[Management Tools](management_tools.md).
+
 Importing `modules.management` exposes convenience functions such as
 `run_portfolio_manager()` and `run_group_analysis()` for launching each tool
 directly.

--- a/modules/generate_report/report_generator.py
+++ b/modules/generate_report/report_generator.py
@@ -58,15 +58,6 @@ def fetch_and_compile(
     obb_mod = _get_openbb()
 
     if local_output is None:
- rezv6y-codex/revamp-documentation-and-contribution-guide
-=======
- main
-        # If a base_output path was provided, assume the caller expects local
-        # files regardless of DIRECTUS_URL. Otherwise default to uploading when
-        # DIRECTUS_URL is configured.
-=======
-
- main
         local_output = bool(base_output or os.getenv("OUTPUT_DIR")) or not bool(
             os.getenv("DIRECTUS_URL")
         )

--- a/modules/management/directus_tools/directus_wizard.py
+++ b/modules/management/directus_tools/directus_wizard.py
@@ -1,3 +1,5 @@
+"""Interactive wizard for basic Directus API operations."""
+
 import json
 
 from modules.interface import (

--- a/modules/management/group_analysis/__init__.py
+++ b/modules/management/group_analysis/__init__.py
@@ -1,0 +1,5 @@
+"""Exports the group analysis CLI entry point."""
+
+from .group_analysis import main as run_group_analysis
+
+__all__ = ["run_group_analysis"]

--- a/modules/management/note_manager/__init__.py
+++ b/modules/management/note_manager/__init__.py
@@ -1,3 +1,5 @@
+"""Public interface for the Markdown note manager CLI."""
+
 from .note_manager import (
     create_note,
     get_note_path,

--- a/modules/management/note_manager/note_manager.py
+++ b/modules/management/note_manager/note_manager.py
@@ -1,5 +1,8 @@
+"""Markdown note system with a minimal interactive CLI."""
+
 import os
 import re
+
 from pathlib import Path
 from typing import List, Optional
 

--- a/modules/management/portfolio_manager/__init__.py
+++ b/modules/management/portfolio_manager/__init__.py
@@ -1,0 +1,2 @@
+"""Expose the portfolio manager CLI entry point."""
+

--- a/modules/management/settings_manager/__init__.py
+++ b/modules/management/settings_manager/__init__.py
@@ -1,1 +1,6 @@
 
+"""Convenience import for the interactive settings manager."""
+
+from .settings_manager import run_settings_manager
+
+__all__ = ["run_settings_manager"]

--- a/modules/management/settings_manager/settings_manager.py
+++ b/modules/management/settings_manager/settings_manager.py
@@ -38,6 +38,7 @@ def _discover_wizards():
 
 
 def _prompt_kv() -> tuple[str, str]:
+    """Prompt for a key/value pair, returning empty strings if canceled."""
     key = input("Key (or press Enter to cancel): ").strip()
     if not key:
         return "", ""
@@ -46,6 +47,7 @@ def _prompt_kv() -> tuple[str, str]:
 
 
 def _show_dict(data: Dict[str, str]) -> None:
+    """Pretty-print a simple key/value mapping."""
     if not data:
         print("(empty)")
     else:
@@ -61,6 +63,7 @@ def _show_api_keys() -> None:
 
 
 def _set_setting() -> None:
+    """Prompt for and save a value in ``settings.json``."""
     key, val = _prompt_kv()
     if not key:
         print("Canceled.\n")
@@ -72,6 +75,7 @@ def _set_setting() -> None:
 
 
 def _del_setting() -> None:
+    """Delete a key from ``settings.json`` if it exists."""
     key = input_or_cancel("Key to delete")
     if not key:
         print("Canceled.\n")
@@ -86,6 +90,7 @@ def _del_setting() -> None:
 
 
 def _set_env_var() -> None:
+    """Add or update an environment variable in ``config/.env``."""
     key, val = _prompt_kv()
     if not key:
         print("Canceled.\n")
@@ -97,6 +102,7 @@ def _set_env_var() -> None:
 
 
 def _del_env_var() -> None:
+    """Remove a variable from ``config/.env`` if present."""
     key = input_or_cancel("Variable to delete")
     if not key:
         print("Canceled.\n")
@@ -110,6 +116,7 @@ def _del_env_var() -> None:
         print("Key not found.\n")
 
 def _general_settings_menu() -> None:
+    """Interactive submenu for managing ``settings.json``."""
     while True:
         print_header("\u2699\ufe0f General Settings")
         options = [
@@ -133,6 +140,7 @@ def _general_settings_menu() -> None:
 
 
 def _env_menu() -> None:
+    """Interactive submenu for editing ``config/.env``."""
     while True:
         print_header("\u2699\ufe0f Environment (.env)")
         options = [
@@ -156,6 +164,7 @@ def _env_menu() -> None:
 
 
 def _wizards_menu() -> None:
+    """Display available setup wizards and run the selected one."""
     wiz_map = {label: func for label, func in _discover_wizards()}
     default_order = [
         "Directus Connection",


### PR DESCRIPTION
## Summary
- document management CLI utilities in new `docs/management_tools.md`
- link from the main overview to the new page
- add missing module docstrings across `modules/management`
- improve helper documentation in `settings_manager`
- fix leftover merge artifact in `report_generator.py`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841ae052fac8327a845877d6788bd15