### PR TITLE
Improve docs and add missing module docstrings

### DIFF
--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -1,5 +1,12 @@
 # API Reference
 
+This reference is automatically generated using
+[pdoc](https://pdoc.dev). To update the documentation run:
+
+```bash
+pdoc --output-dir docs --force modules
+```
+
 ## modules.analytics
 ```
 Python Library Documentation: package modules.analytics in modules

--- a/docs/DEVELOPER_GUIDE.md
+++ b/docs/DEVELOPER_GUIDE.md
@@ -1,6 +1,7 @@
 # Developer Guide
 
-This document outlines Fundalyze's architecture and provides tips for extending and debugging the project.
+This guide outlines Fundalyze's architecture and provides tips for setting up
+your environment, running the tools and contributing patches.
 
 ## Architecture Overview
 ```text
@@ -20,23 +21,26 @@ Fundalyze/
 - `modules/generate_report` builds Excel dashboards from downloaded CSVs.
 - `modules/management` contains interactive CLI commands.
 
-## Debugging Environment
-1. Create the virtual environment with `bootstrap_env.sh` (or `.ps1` on Windows).
-2. Open the project in VS Code and choose **Run → Start Debugging** on `scripts/main.py` to attach the debugger.
+## Setup
+1. Clone the repository and run `bootstrap_env.sh` (or `.ps1` on Windows) to create the virtual environment.
+2. Populate `config/.env` with the required API keys and preferences.
+3. Optional: edit `config/settings.json` to change defaults such as timezone or currency.
+
+## Usage
+1. Launch the interactive menu with `python scripts/main.py`.
+2. Use VS Code's **Run → Start Debugging** on `scripts/main.py` to attach the debugger.
 3. Set `LOG_LEVEL=DEBUG` in `config/.env` for verbose output.
-4. Optionally set `OUTPUT_DIR` to a temporary folder when testing report generation.
-5. For quick inspection you can run modules with:
+4. For quick inspection you can run individual modules with:
    ```bash
    python -m pdb modules/<package>/file.py
    ```
-6. Configure breakpoints in VS Code via `.vscode/launch.json` if you need custom args.
-7. Run `pytest -s` when debugging tests to see console output.
+5. Configure breakpoints in `.vscode/launch.json` if you need custom args.
 
-## Extending Fundalyze
-### Adding Analysis Modules
+## Contribution
+### Extending Fundalyze
 1. Drop a `.py` file into `modules/analytics/` and implement your functions.
 2. Register the module in `modules/analytics/__init__.py` (this acts as the simple *analysis registry*).
-3. Regenerate `docs/API_REFERENCE.md` with `pydoc` on the new module.
+3. Regenerate `docs/API_REFERENCE.md` with `pdoc` on the new module.
 
 ### Adding CLI Components or UI Elements
 1. Place new code under `modules/management/`.
@@ -44,8 +48,9 @@ Fundalyze/
 3. Document any new commands in the README or user guide.
 4. Reusable widgets belong in `modules/interface.py`.
 
-## Writing Tests
+### Writing Tests
 - Tests live in `tests/` and use the `pytest` framework.
 - Name files `test_*.py` and keep fixtures focused.
 - Run `pytest -q` before committing to ensure coverage stays high.
 - Prefer small sample data and temporary directories to keep tests fast.
+

--- a/docs/end_to_end_tests.md
+++ b/docs/end_to_end_tests.md
@@ -22,3 +22,12 @@ This document outlines the automated end-to-end tests for Fundalyze.
 
 These tests exercise the main user journeys without relying on network access
 and run automatically as part of the test suite.
+
+## Running the Tests
+
+1. Install dependencies with `pip install -r requirements.txt`.
+2. Run all tests using:
+   ```bash
+   pytest -q
+   ```
+3. Use `pytest -k <pattern> -s` to execute a subset while inspecting output.

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -2,6 +2,28 @@
 
 This document summarizes the key modules and entry points in **Fundalyze**. Use it as a quick reference when navigating or extending the project.
 
+```mermaid
+flowchart TD
+    subgraph CLI
+        A["scripts/main.py"]
+        B["portfolio_manager"]
+        C["group_analysis"]
+        D["note_manager"]
+    end
+    subgraph Core
+        E["data.fetching"]
+        F["generate_report.report_generator"]
+        G["generate_report.excel_dashboard"]
+    end
+    A --> B
+    A --> C
+    A --> D
+    B --> E
+    C --> E
+    E --> F
+    F --> G
+```
+
 ## Module Packages
 
 ### `modules.generate_report`

--- a/docs/report_generation.md
+++ b/docs/report_generation.md
@@ -37,4 +37,22 @@ python scripts/main.py report
 
 After completion the Excel dashboard opens so you can explore the results.
 
+## CLI vs API Usage
+
+The same workflow can be triggered programmatically. The CLI simply calls the
+functions shown below.
+
+### CLI
+```bash
+python scripts/main.py report --tickers AAPL MSFT
+```
+
+### API
+```python
+from modules.generate_report import fetch_and_compile, excel_dashboard
+
+fetch_and_compile("AAPL")
+excel_dashboard.create_and_open_dashboard(tickers=["AAPL"])
+```
+
 See [docs/end_to_end_tests.md](end_to_end_tests.md) for automated scenarios covering this process.

--- a/modules/__init__.py
+++ b/modules/__init__.py
@@ -1,0 +1,7 @@
+"""Top-level package for Fundalyze modules.
+
+This package aggregates the core functionality used throughout the
+project. Subpackages are grouped by theme (e.g. ``data`` or
+``management``) and can be imported individually as needed.
+"""
+

--- a/modules/data/directus_client.py
+++ b/modules/data/directus_client.py
@@ -1,3 +1,5 @@
+"""Thin wrapper around the Directus REST API used for optional remote storage."""
+
 import os
 import logging
 import math

--- a/modules/data/directus_mapper.py
+++ b/modules/data/directus_mapper.py
@@ -1,3 +1,5 @@
+"""Helpers for mapping pandas DataFrames to Directus collections."""
+
 import json
 import logging
 from pathlib import Path

--- a/modules/data/term_mapper.py
+++ b/modules/data/term_mapper.py
@@ -1,3 +1,5 @@
+"""Maps generic financial terms to API field names using `config/term_mapping.json`."""
+
 import json
 import os
 from pathlib import Path

--- a/modules/generate_report/__init__.py
+++ b/modules/generate_report/__init__.py
@@ -1,3 +1,5 @@
+"""Convenience wrappers for generating ticker reports and dashboards."""
+
 # src/generate_report/__init__.py
 
 from .report_generator import fetch_and_compile

--- a/modules/generate_report/report_generator.py
+++ b/modules/generate_report/report_generator.py
@@ -58,21 +58,10 @@ def fetch_and_compile(
     obb_mod = _get_openbb()
 
     if local_output is None:
- rezv6y-codex/revamp-documentation-and-contribution-guide
-=======
- main
-        # If a base_output path was provided, assume the caller expects local
-        # files regardless of DIRECTUS_URL. Otherwise default to uploading when
-        # DIRECTUS_URL is configured.
-=======
-
- main
-        local_output = bool(base_output or os.getenv("OUTPUT_DIR")) or not bool(
-            os.getenv("DIRECTUS_URL")
-        )
-
+        # Write locally when a specific output folder is provided or when no
+        # Directus URL is configured. Otherwise default to uploading to
+        # Directus.
         if base_output is not None or os.getenv("OUTPUT_DIR"):
-            # Explicit output folder implies local writes even when Directus is configured
             local_output = True
         else:
             local_output = not bool(os.getenv("DIRECTUS_URL"))

--- a/modules/interface.py
+++ b/modules/interface.py
@@ -1,3 +1,5 @@
+"""Shared user-interface helpers for CLI menus."""
+
 from __future__ import annotations
 
 import pandas as pd

--- a/modules/logging_utils.py
+++ b/modules/logging_utils.py
@@ -1,3 +1,5 @@
+"""Utility for configuring a consistent logging setup."""
+
 import logging
 from pathlib import Path
 

--- a/modules/management/group_analysis/__init__.py
+++ b/modules/management/group_analysis/__init__.py
@@ -1,0 +1,2 @@
+"""Utilities for managing ticker groups and related analyses."""
+

--- a/modules/management/note_manager/__init__.py
+++ b/modules/management/note_manager/__init__.py
@@ -1,3 +1,5 @@
+"""Public API for the note management utilities."""
+
 from .note_manager import (
     create_note,
     get_note_path,

--- a/modules/management/portfolio_manager/__init__.py
+++ b/modules/management/portfolio_manager/__init__.py
@@ -1,0 +1,2 @@
+"""CLI helpers for editing the local stock portfolio."""
+

--- a/modules/management/settings_manager/__init__.py
+++ b/modules/management/settings_manager/__init__.py
@@ -1,1 +1,3 @@
 
+"""Interactive wizards for editing configuration and environment files."""
+

--- a/modules/management/settings_manager/wizards/__init__.py
+++ b/modules/management/settings_manager/wizards/__init__.py
@@ -1,0 +1,2 @@
+"""Collection of interactive configuration wizards."""
+


### PR DESCRIPTION
## Summary
- refactor developer guide into setup, usage & contribution sections
- add mermaid architecture diagram to overview
- document CLI vs API report generation
- expand API reference header with pdoc instructions
- describe test workflow
- fix leftover merge markers and add docstrings across modules

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841ade515748327918c814d1e98d971