### PR TITLE
Improve documentation and add test docstrings

### DIFF
--- a/docs/DEVELOPER_GUIDE.md
+++ b/docs/DEVELOPER_GUIDE.md
@@ -49,3 +49,4 @@ Fundalyze/
 - Name files `test_*.py` and keep fixtures focused.
 - Run `pytest -q` before committing to ensure coverage stays high.
 - Prefer small sample data and temporary directories to keep tests fast.
+For a summary of current coverage see `docs/coverage_report.md`.

--- a/docs/coverage_report.md
+++ b/docs/coverage_report.md
@@ -1,0 +1,19 @@
+# Test Coverage Summary
+
+The automated suite was executed with `pytest --cov=modules` using
+`pytest-cov`. The run on the reference environment yielded roughly **11%**
+statement coverage.
+
+```
+modules/__init__.py                   0      0   100%
+modules/analytics/__init__.py        24     17    29%
+...
+TOTAL                               2422   2165    11%
+```
+
+Coverage is expected to remain low until more modules gain dedicated tests, but
+the report helps track progress over time. To generate the report locally run:
+
+```bash
+pytest --cov=modules --cov-report=term
+```

--- a/docs/module_diagrams.md
+++ b/docs/module_diagrams.md
@@ -1,0 +1,15 @@
+# Module Relationships
+
+```mermaid
+graph TD;
+    subgraph Core
+        analytics --> utils
+        data --> config_utils
+        generate_report --> data
+        management --> generate_report
+    end
+    scripts --> management
+    scripts --> generate_report
+```
+
+The diagram highlights the high level dependencies between major packages.

--- a/modules/generate_report/__init__.py
+++ b/modules/generate_report/__init__.py
@@ -1,3 +1,4 @@
+"""Public API for the report generation package."""
 # src/generate_report/__init__.py
 
 from .report_generator import fetch_and_compile

--- a/modules/generate_report/utils.py
+++ b/modules/generate_report/utils.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+"""Miscellaneous helper functions used by report generators."""
 
 import time
 

--- a/modules/interface.py
+++ b/modules/interface.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+"""User interface helper functions for CLI menus and tables."""
 
 import pandas as pd
 from tabulate import tabulate

--- a/modules/logging_utils.py
+++ b/modules/logging_utils.py
@@ -1,3 +1,4 @@
+"""Central logging configuration helpers."""
 import logging
 from pathlib import Path
 

--- a/modules/management/directus_tools/directus_wizard.py
+++ b/modules/management/directus_tools/directus_wizard.py
@@ -1,3 +1,4 @@
+"""Interactive wizard for configuring Directus integration."""
 import json
 
 from modules.interface import (

--- a/modules/management/note_manager/note_manager.py
+++ b/modules/management/note_manager/note_manager.py
@@ -1,3 +1,4 @@
+"""Markdown note management utilities."""
 import os
 import re
 from pathlib import Path

--- a/modules/management/portfolio_manager/__init__.py
+++ b/modules/management/portfolio_manager/__init__.py
@@ -1,0 +1,2 @@
+"""Portfolio manager CLI entry point."""
+

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,43 @@
+# Test Suite Overview
+
+This folder contains all automated tests for **Fundalyze**.  File names follow
+`test_<component>.py` with optional `_extra` or `_edge` suffixes for additional
+cases.  Tests are grouped by the package they exercise:
+
+## Analytics
+- `test_analysis.py` – analytics helper functions
+
+## Configuration
+- `test_config_utils.py` – settings and `.env` handling
+- `test_output_dir_env.py` – environment variable overrides
+
+## Data Utilities
+- `test_fetching.py` – stock data retrieval helpers
+- `test_directus_client.py` – Directus API wrapper
+- `test_directus_mapper.py` – mapping of Directus schema
+- `test_directus_mapper_extra.py` – extra mapping scenarios
+- `test_data_utils_edge.py` – edge cases for CSV/JSON helpers
+- `test_data_compare_extra.py` – additional compare logic
+- `test_diff.py` – regression tests for `diff_dict`
+
+## Generate Report
+- `test_excel_dashboard.py` – build Excel workbooks
+- `test_excel_dashboard_extra.py` – additional dashboard tests
+- `test_fallback_data.py` – yfinance fallback paths
+- `test_metadata_checker.py` – metadata repair utility
+
+## Management Tools
+- `test_portfolio_manager.py` – portfolio CLI
+- `test_group_analysis.py` – group management CLI
+- `test_note_manager.py` – markdown note system
+- `test_management_package.py` – package exports
+- `test_directus_tools_init.py` – Directus wizard entry point
+
+## Integration / End-to-End
+- `test_interactive_profile.py` – user prompts for profile selection
+- `test_sync_directus_fields.py` – sync Directus metadata
+- `test_integration.py` – multiple modules together
+- `test_e2e.py` – high level workflow
+
+Extra test files (`*_extra.py`, `*_edge.py`) hold miscellaneous scenarios that
+supplement the main tests without cluttering them.

--- a/tests/test_analysis.py
+++ b/tests/test_analysis.py
@@ -1,3 +1,4 @@
+"""Unit tests for analytics helper functions."""
 import pandas as pd
 from analytics import portfolio_summary, sector_counts
 import pytest

--- a/tests/test_config_utils.py
+++ b/tests/test_config_utils.py
@@ -1,3 +1,4 @@
+"""Unit tests for configuration loading utilities."""
 import json
 import modules.config_utils as config_utils
 

--- a/tests/test_data_compare_extra.py
+++ b/tests/test_data_compare_extra.py
@@ -1,3 +1,4 @@
+"""Edge-case tests for data.compare helpers."""
 import pandas as pd
 from data.compare import is_complete
 

--- a/tests/test_data_utils_edge.py
+++ b/tests/test_data_utils_edge.py
@@ -1,3 +1,4 @@
+"""Tests for data utility edge scenarios."""
 import pandas as pd
 from modules.utils.data_utils import (
     ensure_period_column,

--- a/tests/test_diff.py
+++ b/tests/test_diff.py
@@ -1,3 +1,4 @@
+"""Regression tests for diff_dict helper."""
 from data.compare import diff_dict
 
 

--- a/tests/test_directus_client.py
+++ b/tests/test_directus_client.py
@@ -1,3 +1,4 @@
+"""Tests for the Directus API client wrapper."""
 
 import modules.data.directus_client as dc
 

--- a/tests/test_directus_mapper.py
+++ b/tests/test_directus_mapper.py
@@ -1,3 +1,4 @@
+"""Tests for Directus schema mapping."""
 from pathlib import Path
 import json
 import modules.data.directus_mapper as dm

--- a/tests/test_directus_mapper_extra.py
+++ b/tests/test_directus_mapper_extra.py
@@ -1,3 +1,4 @@
+"""Additional mapping scenarios for Directus utilities."""
 import json
 import pandas as pd
 import modules.data.directus_mapper as dm

--- a/tests/test_directus_tools_init.py
+++ b/tests/test_directus_tools_init.py
@@ -1,3 +1,4 @@
+"""Ensure directus_tools exposes run_directus_wizard."""
 import inspect
 
 from modules.management.directus_tools import run_directus_wizard

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -1,3 +1,4 @@
+"""End-to-end integration tests for report generation."""
 import pandas as pd
 from openpyxl import load_workbook
 

--- a/tests/test_excel_dashboard.py
+++ b/tests/test_excel_dashboard.py
@@ -1,3 +1,4 @@
+"""Tests for Excel dashboard creation utilities."""
 import pandas as pd
 import pytest
 from generate_report.excel_dashboard import (

--- a/tests/test_excel_dashboard_extra.py
+++ b/tests/test_excel_dashboard_extra.py
@@ -1,3 +1,4 @@
+"""Extra cases for Excel dashboard helpers."""
 import pytest
 import pandas as pd
 from modules.generate_report.excel_dashboard import (

--- a/tests/test_fallback_data.py
+++ b/tests/test_fallback_data.py
@@ -1,3 +1,4 @@
+"""Tests for yfinance fallback data retrieval."""
 import json
 import pandas as pd
 from unittest.mock import MagicMock

--- a/tests/test_fetching.py
+++ b/tests/test_fetching.py
@@ -1,3 +1,4 @@
+"""Tests for stock data fetching functions."""
 from unittest.mock import MagicMock, patch
 
 from modules.data.fetching import fetch_basic_stock_data, fetch_basic_stock_data_batch

--- a/tests/test_group_analysis.py
+++ b/tests/test_group_analysis.py
@@ -1,3 +1,4 @@
+"""Unit tests for group analysis CLI tool."""
 import pandas as pd
 import modules.management.group_analysis.group_analysis as ga
 

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1,3 +1,4 @@
+"""High level integration tests across modules."""
 import pandas as pd
 from unittest.mock import MagicMock
 

--- a/tests/test_interactive_profile.py
+++ b/tests/test_interactive_profile.py
@@ -1,3 +1,4 @@
+"""Tests for interactive profile selection logic."""
 import pandas as pd
 import modules.data.compare as cmp
 

--- a/tests/test_interface_extra.py
+++ b/tests/test_interface_extra.py
@@ -1,3 +1,4 @@
+"""Additional tests for interface presentation functions."""
 import pandas as pd
 from modules.interface import print_table
 

--- a/tests/test_management_package.py
+++ b/tests/test_management_package.py
@@ -1,3 +1,4 @@
+"""Verify management package exports CLI entry points."""
 from modules.management import (
     run_portfolio_manager,
     run_group_analysis,

--- a/tests/test_metadata_checker.py
+++ b/tests/test_metadata_checker.py
@@ -1,3 +1,4 @@
+"""Tests for metadata_checker re-fetch workflow."""
 import pandas as pd
 from unittest.mock import MagicMock
 import pytest

--- a/tests/test_note_manager.py
+++ b/tests/test_note_manager.py
@@ -1,3 +1,4 @@
+"""Tests for the Markdown note management system."""
 import os
 import tempfile
 

--- a/tests/test_output_dir_env.py
+++ b/tests/test_output_dir_env.py
@@ -1,3 +1,4 @@
+"""Validate OUTPUT_DIR environment variable handling."""
 import pandas as pd
 
 import modules.generate_report.report_generator as rg

--- a/tests/test_portfolio_manager.py
+++ b/tests/test_portfolio_manager.py
@@ -1,3 +1,4 @@
+"""Tests for portfolio manager CLI operations."""
 import pandas as pd
 import modules.management.portfolio_manager.portfolio_manager as pm
 

--- a/tests/test_progress_utils.py
+++ b/tests/test_progress_utils.py
@@ -1,3 +1,4 @@
+"""Tests for progress indicator helper."""
 from modules.utils.progress_utils import progress_iter
 
 

--- a/tests/test_sync_directus_fields.py
+++ b/tests/test_sync_directus_fields.py
@@ -1,3 +1,4 @@
+"""Tests for syncing Directus field metadata."""
 import importlib
 import json
 

--- a/tests/test_term_mapper.py
+++ b/tests/test_term_mapper.py
@@ -1,3 +1,4 @@
+"""Tests for term mapping utilities."""
 from pathlib import Path
 from modules.data.term_mapper import MAPPING_FILE, load_mapping
 

--- a/tests/test_term_mapper_extra.py
+++ b/tests/test_term_mapper_extra.py
@@ -1,3 +1,4 @@
+"""Extra scenarios for term_mapper helpers."""
 import importlib
 from modules.data import term_mapper
 


### PR DESCRIPTION
## Summary
- document public modules and add diagrams
- add README for tests and coverage report
- insert short docstring headers in all tests
- clarify coverage location in developer docs

## Testing
- `pytest -q`
- `pytest --cov=modules --cov-report=term -q`

------
https://chatgpt.com/codex/tasks/task_e_6841ae166ac483279665956aa4cdc6d7