### PR TITLE
Improve docs and add module docstrings

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,9 +45,11 @@ Create `config/.env` and add your API tokens:
 ```env
 OPENBB_TOKEN=your-openbb-token
 FMP_API_KEY=your-fmp-key
+DIRECTUS_URL=https://your-directus.example.com
+DIRECTUS_API_TOKEN=secret-token
 OUTPUT_DIR=output
 ```
-See [docs/configuration.md](docs/configuration.md) for all options.
+The [configuration guide](docs/configuration.md) lists every supported variable.
 
 ## Quickstart
 Run the interactive menu:
@@ -84,7 +86,13 @@ Open the workbook to explore profile information, prices and statements.
 
 ## Resources
 - [User Documentation](docs/overview.md)
+- [Getting Started](docs/GETTING_STARTED.md)
 - [Developer Guide](docs/DEVELOPER_GUIDE.md)
+- [Configuration](docs/configuration.md)
+- [API Reference](docs/API_REFERENCE.md)
+- [Report Generation](docs/report_generation.md)
+- [Performance Benchmarks](docs/performance_benchmarks.md)
+- [End-to-End Tests](docs/end_to_end_tests.md)
 - [Issue Tracker](https://github.com/VeraLIMS/Fundalyze/issues)
 - Community chat (coming soon)
 

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -1,0 +1,32 @@
+# Getting Started
+
+This guide helps new contributors set up a local Fundalyze environment.
+
+## Prerequisites
+- **Python 3.11** or later
+- **Git** and a recent version of **pip**
+
+## Setup Steps
+1. Fork and clone the repository.
+2. Run `./bootstrap_env.sh` (or `bootstrap_env.ps1` on Windows). This creates
+   `.venv` and installs all dependencies from `requirements.txt`.
+3. Copy `config/.env` from the example below and fill in your API keys.
+4. Run `python scripts/main.py` to open the interactive menu.
+
+## Example `.env`
+```env
+OPENBB_TOKEN=your-openbb-key
+FMP_API_KEY=your-fmp-key
+DIRECTUS_URL=https://your-directus.example.com
+DIRECTUS_API_TOKEN=secret-token
+OUTPUT_DIR=output
+```
+See [configuration.md](configuration.md) for the full list of optional
+variables and detailed explanations.
+
+## Running Tests
+Activate the virtual environment and execute:
+```bash
+pytest -q
+```
+All tests should pass before submitting a pull request.

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -2,6 +2,26 @@
 
 This document summarizes the key modules and entry points in **Fundalyze**. Use it as a quick reference when navigating or extending the project.
 
+```mermaid
+graph TD
+    Main[CLI]
+    subgraph Management
+        PM[portfolio_manager]
+        GA[group_analysis]
+        NM[note_manager]
+    end
+    subgraph Reporting
+        RG[report_generator]
+        DB[excel_dashboard]
+        MC[metadata_checker]
+    end
+    Data{{data package}}
+    Main --> Management
+    Main --> Reporting
+    Reporting --> Data
+    Management --> Data
+```
+
 ## Module Packages
 
 ### `modules.generate_report`

--- a/modules/data/directus_client.py
+++ b/modules/data/directus_client.py
@@ -1,3 +1,5 @@
+"""Minimal Directus API client used for optional remote storage."""
+
 import os
 import logging
 import math

--- a/modules/data/directus_mapper.py
+++ b/modules/data/directus_mapper.py
@@ -1,3 +1,5 @@
+"""Helpers for mapping DataFrame columns to Directus collections."""
+
 import json
 import logging
 from pathlib import Path

--- a/modules/data/term_mapper.py
+++ b/modules/data/term_mapper.py
@@ -1,3 +1,5 @@
+"""Map API-specific sector/industry terms to canonical names."""
+
 import json
 import os
 from pathlib import Path

--- a/modules/generate_report/__init__.py
+++ b/modules/generate_report/__init__.py
@@ -1,4 +1,4 @@
-# src/generate_report/__init__.py
+"""Public entry points for the report generation workflow."""
 
 from .report_generator import fetch_and_compile
 from .metadata_checker import run_for_tickers

--- a/modules/generate_report/excel_dashboard.py
+++ b/modules/generate_report/excel_dashboard.py
@@ -1,4 +1,4 @@
-# src/generate_report/excel_dashboard.py
+"""Create Excel workbooks from downloaded report data."""
 
 import os
 import subprocess

--- a/modules/generate_report/report_generator.py
+++ b/modules/generate_report/report_generator.py
@@ -58,23 +58,11 @@ def fetch_and_compile(
     obb_mod = _get_openbb()
 
     if local_output is None:
- rezv6y-codex/revamp-documentation-and-contribution-guide
-=======
- main
-        # If a base_output path was provided, assume the caller expects local
-        # files regardless of DIRECTUS_URL. Otherwise default to uploading when
-        # DIRECTUS_URL is configured.
-=======
-
- main
-        local_output = bool(base_output or os.getenv("OUTPUT_DIR")) or not bool(
-            os.getenv("DIRECTUS_URL")
-        )
-
         if base_output is not None or os.getenv("OUTPUT_DIR"):
             # Explicit output folder implies local writes even when Directus is configured
             local_output = True
         else:
+            # Default to uploading to Directus when the URL is set
             local_output = not bool(os.getenv("DIRECTUS_URL"))
 
     ticker_dir = rutils.ensure_output_dir(symbol, base_output) if local_output else (base_output or ".")

--- a/modules/generate_report/utils.py
+++ b/modules/generate_report/utils.py
@@ -1,3 +1,5 @@
+"""Miscellaneous helpers used by report generation modules."""
+
 from __future__ import annotations
 
 import time

--- a/modules/generate_report/yf_fallback.py
+++ b/modules/generate_report/yf_fallback.py
@@ -1,4 +1,4 @@
-# src/generate_report/yf_fallback.py
+"""Standalone fallback data fetch using yfinance/FMP when primary calls fail."""
 
 import yfinance as yf
 import pandas as pd

--- a/modules/interface.py
+++ b/modules/interface.py
@@ -1,3 +1,5 @@
+"""Reusable console interface helpers for CLI tools."""
+
 from __future__ import annotations
 
 import pandas as pd

--- a/modules/logging_utils.py
+++ b/modules/logging_utils.py
@@ -1,3 +1,6 @@
+
+"""Configure consistent application logging."""
+
 import logging
 from pathlib import Path
 

--- a/modules/management/directus_tools/directus_wizard.py
+++ b/modules/management/directus_tools/directus_wizard.py
@@ -1,3 +1,5 @@
+"""Interactive wizard for Directus integration setup and field mapping."""
+
 import json
 
 from modules.interface import (

--- a/modules/management/note_manager/__init__.py
+++ b/modules/management/note_manager/__init__.py
@@ -1,3 +1,5 @@
+"""Convenience imports for the note management CLI."""
+
 from .note_manager import (
     create_note,
     get_note_path,

--- a/modules/management/note_manager/note_manager.py
+++ b/modules/management/note_manager/note_manager.py
@@ -1,3 +1,5 @@
+"""Simple Markdown note management with wiki-style links."""
+
 import os
 import re
 from pathlib import Path

--- a/modules/management/portfolio_manager/__init__.py
+++ b/modules/management/portfolio_manager/__init__.py
@@ -1,0 +1,1 @@
+"""Expose the portfolio manager CLI helpers."""

--- a/modules/management/settings_manager/__init__.py
+++ b/modules/management/settings_manager/__init__.py
@@ -1,1 +1,1 @@
-
+"""Launchers and helpers for the interactive settings manager."""


### PR DESCRIPTION
## Summary
- document environment variables in README
- add quick start guide for contributors
- add module diagram to code overview
- add missing module-level docstrings
- fix stray merge markers in report generator

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841ae1bd07c83278e262c6f330f89fc