### PR TITLE
Fix stray codex markers

### DIFF
--- a/modules/generate_report/report_generator.py
+++ b/modules/generate_report/report_generator.py
@@ -1,19 +1,11 @@
-"""Utility for creating markdown reports from market data.
+"""
+script: report_generator.py
 
-``report_generator.py`` coordinates OpenBB calls to fetch a company's profile,
-price history and financial statements.  Each dataset is written to ``CSV`` and
-optionally ``JSON``.  The function then compiles a markdown summary and a
-``metadata.json`` file describing the source of every output.  The goal is to
-produce a self‑contained folder under ``output/<TICKER>/`` that can later be
-checked by :mod:`metadata_checker` and included in the Excel dashboard.
+Dependencies:
+    pip install openbb[all] matplotlib pandas
 
-Dependencies
-------------
-``pip install openbb[all] matplotlib pandas``
-
-Example
--------
-``python src/report_generator.py AAPL MSFT GOOGL``
+Usage:
+    python src/report_generator.py AAPL MSFT GOOGL
 """
 
 from __future__ import annotations
@@ -48,14 +40,6 @@ def fetch_and_compile(
 ) -> None:
     """Generate all report files for ``symbol``.
 
-    The function orchestrates every step required to populate a ticker folder.
-    It calls helper functions from :mod:`report_utils` to fetch the profile,
-    price history and financial statements.  Markdown lines describing each
-    action are accumulated in ``lines`` and finally written to ``report.md``.
-    ``metadata.json`` is updated in parallel with details about the data source
-    or, if an error occurs, an ``ERROR`` entry which later triggers the
-    fallback utilities.
-
     Parameters
     ----------
     symbol:
@@ -74,70 +58,11 @@ def fetch_and_compile(
     obb_mod = _get_openbb()
 
     if local_output is None:
- codex/create-comprehensive-documentation-for-fundalyze
         if base_output is not None or os.getenv("OUTPUT_DIR"):
-=======
- codex/document-cli-management-tools-and-helpers
-=======
- codex/document-utilities-in-analytics-module
-        # If a base_output path was provided, assume the caller expects local
-        # files regardless of DIRECTUS_URL. Otherwise default to uploading when
-        # DIRECTUS_URL is configured.
-=======
- codex/document-scripts-folder-and-add-headers
-        # If a base_output path was provided, assume the caller expects local
-        # files regardless of DIRECTUS_URL. Otherwise default to uploading when
-        # DIRECTUS_URL is not configured.
-=======
- codex/document-logging_utils.py-usage
- codex/document-logging_utils.py-usage
-
-=======
- codex/document-logs-and-logging-policy
-        # If a ``base_output`` path was provided, assume the caller expects
-        # local files regardless of DIRECTUS_URL. Otherwise default to uploading
-        # when DIRECTUS_URL is configured.
-=======
- codex/create-documentation-for-generate_report-module
-=======
- nwk644-codex/document-utilities-in-analytics-module
- main
-        # If a base_output path was provided, assume the caller expects local
-        # files regardless of DIRECTUS_URL. Otherwise default to uploading when
-        # DIRECTUS_URL is configured.
- main
- main
- main
- main
- main
-        local_output = bool(base_output or os.getenv("OUTPUT_DIR")) or not bool(
-            os.getenv("DIRECTUS_URL")
-        )
-=======
- codex/document-config-folder-files
-        # If a base_output path was provided, assume the caller expects local
-        # files regardless of DIRECTUS_URL. Otherwise default to uploading when
-        # DIRECTUS_URL is configured.
-        local_output = bool(base_output or os.getenv("OUTPUT_DIR")) or not bool(os.getenv("DIRECTUS_URL"))
- main
-
- codex/document-scripts-folder-and-add-headers
-=======
-        if base_output is not None or os.getenv("OUTPUT_DIR"):
-            # Explicit output folder implies local writes even when Directus is
-            # configured
-=======
-        # Write locally when a specific output folder is provided or when no
-        # Directus URL is configured. Otherwise default to uploading to
-        # Directus.
-        if base_output is not None or os.getenv("OUTPUT_DIR"):
- main
- main
             local_output = True
         else:
             local_output = not bool(os.getenv("DIRECTUS_URL"))
 
- main
     ticker_dir = rutils.ensure_output_dir(symbol, base_output) if local_output else (base_output or ".")
     metadata = {
         "ticker": symbol.upper(),

--- a/modules/interface.py
+++ b/modules/interface.py
@@ -1,11 +1,6 @@
-codex/create-comprehensive-documentation-for-fundalyze
 """Common CLI interface helpers used across modules."""
-=======
-"""Shared user-interface helpers for CLI menus."""
- main
 
 from __future__ import annotations
-"""User interface helper functions for CLI menus and tables."""
 
 import pandas as pd
 from tabulate import tabulate

--- a/modules/logging_utils.py
+++ b/modules/logging_utils.py
@@ -1,18 +1,3 @@
- codex/create-comprehensive-documentation-for-fundalyze
-"""Logging configuration helpers."""
-
-=======
- codex/create-documentation-for-tests-module
-"""Central logging configuration helpers."""
-=======
- codex/document-logging_utils.py-usage
- codex/document-logging_utils.py-usage
-"""Simple logging configuration helper.
-
-Use :func:`setup_logging` at application startup to create ``fundalyze.log``
-and enable console output.  Log records use the format::
-=======
- codex/document-logs-and-logging-policy
 """Shared logging helpers used across Fundalyze utilities.
 
 The :func:`setup_logging` function configures the root ``logging`` package to
@@ -24,22 +9,11 @@ immediately through Python's standard logging handlers.
 No rotation is currently configured; the log file will grow until manually
 deleted or rotated by external tooling.
 """
- main
-=======
-"""Utility for configuring a consistent logging setup."""
- main
-
- main
- main
-import logging
-from pathlib import Path
- main
-
-    YYYY-MM-DD HH:MM:SS [LEVEL] logger: message
-"""
 
 import logging
 from pathlib import Path
+
+
 def setup_logging(log_file: str = "fundalyze.log", level: int = logging.DEBUG) -> None:
     """Configure the root logger and open ``log_file``.
 
@@ -51,17 +25,10 @@ def setup_logging(log_file: str = "fundalyze.log", level: int = logging.DEBUG) -
     level:
         Logging level for the root logger.
 
- codex/document-logging_utils.py-usage
-    Example
-    -------
-    >>> from modules.logging_utils import setup_logging
-    >>> setup_logging("logs/fundalyze.log")
-=======
     Notes
     -----
     ``logging`` handles flushes automatically when the program exits or handlers
     are closed, so this function does not need to call ``flush()`` manually.
- main
     """
     path = Path(log_file)
     path.parent.mkdir(parents=True, exist_ok=True)

--- a/modules/management/directus_tools/directus_wizard.py
+++ b/modules/management/directus_tools/directus_wizard.py
@@ -1,14 +1,5 @@
- codex/create-comprehensive-documentation-for-fundalyze
 """Interactive wizard for configuring Directus integration."""
 
-=======
- codex/create-documentation-for-tests-module
-"""Interactive wizard for configuring Directus integration."""
-=======
-"""Interactive wizard for basic Directus API operations."""
-
- main
- main
 import json
 
 from modules.interface import (

--- a/modules/management/group_analysis/__init__.py
+++ b/modules/management/group_analysis/__init__.py
@@ -1,14 +1,1 @@
- codex/create-comprehensive-documentation-for-fundalyze
 """CLI tools for managing groups of related tickers."""
-=======
- codex/document-cli-management-tools-and-helpers
-"""Exports the group analysis CLI entry point."""
-
-from .group_analysis import main as run_group_analysis
-
-__all__ = ["run_group_analysis"]
-=======
-"""Utilities for managing ticker groups and related analyses."""
-
- main
-main

--- a/modules/management/note_manager/__init__.py
+++ b/modules/management/note_manager/__init__.py
@@ -1,12 +1,5 @@
- codex/create-comprehensive-documentation-for-fundalyze
 """Helpers for the Markdown note management system."""
-=======
- codex/document-cli-management-tools-and-helpers
-"""Public interface for the Markdown note manager CLI."""
-=======
-"""Public API for the note management utilities."""
- main
- main
+
 from .note_manager import (
     create_note,
     get_note_path,

--- a/modules/management/note_manager/note_manager.py
+++ b/modules/management/note_manager/note_manager.py
@@ -1,17 +1,7 @@
- codex/create-comprehensive-documentation-for-fundalyze
 """Command line note manager with wiki-style links."""
 
-=======
- codex/create-documentation-for-tests-module
-"""Markdown note management utilities."""
-=======
-"""Markdown note system with a minimal interactive CLI."""
-
- main
- main
 import os
 import re
-
 from pathlib import Path
 from typing import List, Optional
 

--- a/modules/management/portfolio_manager/__init__.py
+++ b/modules/management/portfolio_manager/__init__.py
@@ -1,13 +1,1 @@
- codex/create-comprehensive-documentation-for-fundalyze
 """CLI for editing and viewing portfolio.xlsx."""
-=======
- codex/create-documentation-for-tests-module
-"""Portfolio manager CLI entry point."""
-=======
- codex/document-cli-management-tools-and-helpers
-"""Expose the portfolio manager CLI entry point."""
-=======
-"""CLI helpers for editing the local stock portfolio."""
- main
- main
- main

--- a/modules/management/settings_manager/__init__.py
+++ b/modules/management/settings_manager/__init__.py
@@ -1,14 +1,1 @@
-codex/create-comprehensive-documentation-for-fundalyze
 """Interactive manager for Fundalyze configuration settings."""
-=======
-
- codex/document-cli-management-tools-and-helpers
-"""Convenience import for the interactive settings manager."""
-
-from .settings_manager import run_settings_manager
-
-__all__ = ["run_settings_manager"]
-=======
-"""Interactive wizards for editing configuration and environment files."""
-
- main

--- a/modules/management/settings_manager/wizards/__init__.py
+++ b/modules/management/settings_manager/wizards/__init__.py
@@ -1,6 +1,1 @@
- codex/create-comprehensive-documentation-for-fundalyze
 """Subcommands used by the settings manager wizard."""
-=======
-"""Collection of interactive configuration wizards."""
-
- main


### PR DESCRIPTION
## Summary
- restore clean versions of core modules after documentation merge
- remove codex marker text from management package and interface utilities
- ensure logging helper and report generator run correctly

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841b6fe98408327ac14548b4d2ad0af