### PR TITLE
Fix CLI modules and logging utilities

### DIFF
--- a/modules/generate_report/report_utils.py
+++ b/modules/generate_report/report_utils.py
@@ -27,7 +27,13 @@ def ensure_output_dir(symbol: str, base_output: str | None = None) -> str:
 
 def upload_dataframe(df: pd.DataFrame, collection: str) -> None:
     """Insert DataFrame rows into a Directus collection if configured."""
-    if not bool(os.getenv("DIRECTUS_URL")) or df.empty:
+    if (
+        not os.getenv("DIRECTUS_URL")
+        or not (
+            os.getenv("DIRECTUS_API_TOKEN") or os.getenv("DIRECTUS_TOKEN")
+        )
+        or df.empty
+    ):
         return
     records = prepare_records(collection, df.to_dict(orient="records"))
     try:

--- a/modules/logging_utils.py
+++ b/modules/logging_utils.py
@@ -1,9 +1,8 @@
- codex/refactor-and-improve-core-fundalyze-functions
 """Shared logging helpers used across Fundalyze utilities.
 
 The :func:`setup_logging` function configures the root ``logging`` package to
 write messages both to the console and to ``fundalyze.log`` under the project
-``logs/`` directory.  Each log entry uses the format
+``logs/`` directory. Each log entry uses the format
 ``YYYY-MM-DD HH:MM:SS [LEVEL] logger_name: message`` and is written
 immediately through Python's standard logging handlers.
 
@@ -11,9 +10,6 @@ No rotation is currently configured; the log file will grow until manually
 deleted or rotated by external tooling.
 """
 
-=======
-"""Central logging configuration helpers."""
- main
 import logging
 from pathlib import Path
 
@@ -24,18 +20,14 @@ def setup_logging(log_file: str = "fundalyze.log", level: int = logging.DEBUG) -
     Parameters
     ----------
     log_file:
-        File path where logs will be written. Directory will be created if
-        needed.
+        File path where logs will be written. Directory will be created if needed.
     level:
         Logging level for the root logger.
- codex/refactor-and-improve-core-fundalyze-functions
 
     Notes
     -----
     ``logging`` handles flushes automatically when the program exits or handlers
     are closed, so this function does not need to call ``flush()`` manually.
-=======
- main
     """
     path = Path(log_file)
     path.parent.mkdir(parents=True, exist_ok=True)

--- a/modules/management/directus_tools/directus_wizard.py
+++ b/modules/management/directus_tools/directus_wizard.py
@@ -1,8 +1,4 @@
- codex/refactor-and-improve-core-fundalyze-functions
-"""Interactive wizard for configuring Directus integration."""
-=======
 """Interactive wizard for basic Directus API operations."""
- main
 
 import json
 

--- a/modules/management/group_analysis/__init__.py
+++ b/modules/management/group_analysis/__init__.py
@@ -1,9 +1,5 @@
- codex/refactor-and-improve-core-fundalyze-functions
-"""CLI tools for managing groups of related tickers."""
-=======
 """Exports the group analysis CLI entry point."""
 
 from .group_analysis import main as run_group_analysis
 
 __all__ = ["run_group_analysis"]
- main

--- a/modules/management/portfolio_manager/__init__.py
+++ b/modules/management/portfolio_manager/__init__.py
@@ -1,6 +1,5 @@
- codex/refactor-and-improve-core-fundalyze-functions
-"""CLI for editing and viewing portfolio.xlsx."""
-=======
 """Expose the portfolio manager CLI entry point."""
 
- main
+from .portfolio_manager import main
+
+__all__ = ["main"]

--- a/modules/management/settings_manager/__init__.py
+++ b/modules/management/settings_manager/__init__.py
@@ -1,10 +1,5 @@
- codex/refactor-and-improve-core-fundalyze-functions
-"""Interactive manager for Fundalyze configuration settings."""
-=======
-
 """Convenience import for the interactive settings manager."""
 
 from .settings_manager import run_settings_manager
 
 __all__ = ["run_settings_manager"]
- main

--- a/modules/management/settings_manager/wizards/__init__.py
+++ b/modules/management/settings_manager/wizards/__init__.py
@@ -1,6 +1,3 @@
- codex/refactor-and-improve-core-fundalyze-functions
-"""Subcommands used by the settings manager wizard."""
-=======
 """Collection of interactive configuration wizards."""
 
- main
+# Individual wizard entry points are imported lazily by settings_manager


### PR DESCRIPTION
## Summary
- clean up leftover merge artifacts across logging and management modules
- guard Directus uploads when authentication is missing
- ensure CLI packages export expected entry points

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841bf039164832790e2bc02dff1b074