### PR TITLE
Fix CLI report workflow uses local output

### DIFF
--- a/modules/generate_report/__init__.py
+++ b/modules/generate_report/__init__.py
@@ -96,7 +96,9 @@ def run_generate_report():
         return
     for tk in tickers:
         try:
-            fetch_and_compile(tk)
+            # Always write files locally so subsequent steps (metadata checker,
+            # fallback fetch and dashboard creation) have data to work with.
+            fetch_and_compile(tk, local_output=True)
         except Exception as e:
             print(f"  ⚠ Error while generating report for {tk}: {e}")
 


### PR DESCRIPTION
## Summary
- ensure generated reports save local files when running via the CLI

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841c55d7fd48327b2214667cac6c873