### PR TITLE
Fix Cloudflare Access wizard headers

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -31,7 +31,8 @@ inside the Settings Manager to store the token. The Settings Manager also
  directory**. Another wizard sets the **Output Directory** used for reports.
  A **Cloudflare Access** wizard stores the `CF_ACCESS_CLIENT_ID` and
  `CF_ACCESS_CLIENT_SECRET` variables required when your Directus instance is
- protected by Cloudflare Access.
+ protected by Cloudflare Access. These map to the `CF-Access-Client-Id` and
+ `CF-Access-Client-Secret` HTTP headers.
  Similarly, obtain a Financial Modeling Prep key from
  [fmp](https://financialmodelingprep.com/) and run the **FMP API Key** wizard
  to store it in `.env`. If you already exported these variables in your shell,

--- a/modules/data/directus_client.py
+++ b/modules/data/directus_client.py
@@ -13,8 +13,13 @@ load_settings()  # ensure .env is read when this module is imported
 DIRECTUS_URL = os.getenv("DIRECTUS_URL", "http://localhost:8055")
 # Support legacy DIRECTUS_TOKEN as well as DIRECTUS_API_TOKEN
 DIRECTUS_TOKEN = os.getenv("DIRECTUS_API_TOKEN") or os.getenv("DIRECTUS_TOKEN")
-CF_ACCESS_CLIENT_ID = os.getenv("CF_ACCESS_CLIENT_ID")
-CF_ACCESS_CLIENT_SECRET = os.getenv("CF_ACCESS_CLIENT_SECRET")
+# Support both underscore and hyphen env var names for Cloudflare credentials
+CF_ACCESS_CLIENT_ID = os.getenv("CF_ACCESS_CLIENT_ID") or os.getenv(
+    "CF-Access-Client-Id"
+)
+CF_ACCESS_CLIENT_SECRET = os.getenv("CF_ACCESS_CLIENT_SECRET") or os.getenv(
+    "CF-Access-Client-Secret"
+)
 
 logger = logging.getLogger(__name__)
 
@@ -36,8 +41,12 @@ def reload_env() -> None:
     global DIRECTUS_URL, DIRECTUS_TOKEN, CF_ACCESS_CLIENT_ID, CF_ACCESS_CLIENT_SECRET
     DIRECTUS_URL = os.getenv("DIRECTUS_URL", "http://localhost:8055")
     DIRECTUS_TOKEN = os.getenv("DIRECTUS_API_TOKEN") or os.getenv("DIRECTUS_TOKEN")
-    CF_ACCESS_CLIENT_ID = os.getenv("CF_ACCESS_CLIENT_ID")
-    CF_ACCESS_CLIENT_SECRET = os.getenv("CF_ACCESS_CLIENT_SECRET")
+    CF_ACCESS_CLIENT_ID = os.getenv("CF_ACCESS_CLIENT_ID") or os.getenv(
+        "CF-Access-Client-Id"
+    )
+    CF_ACCESS_CLIENT_SECRET = os.getenv("CF_ACCESS_CLIENT_SECRET") or os.getenv(
+        "CF-Access-Client-Secret"
+    )
 
 
 def _headers():

--- a/modules/management/settings_manager/wizards/cf_access.py
+++ b/modules/management/settings_manager/wizards/cf_access.py
@@ -10,10 +10,8 @@ def run_wizard() -> None:
     env = load_env()
     current_id = env.get("CF_ACCESS_CLIENT_ID", "")
     current_secret = env.get("CF_ACCESS_CLIENT_SECRET", "")
-    client_id = input(f"CF-Access-Client-Id [{current_id}]: ").strip() or current_id
-    client_secret = (
-        input(f"CF-Access-Client-Secret [{current_secret}]: ").strip() or current_secret
-    )
+    client_id = input("CF-Access-Client-Id: ").strip() or current_id
+    client_secret = input("CF-Access-Client-Secret: ").strip() or current_secret
     if client_id:
         env["CF_ACCESS_CLIENT_ID"] = client_id
     if client_secret:


### PR DESCRIPTION
### Summary
- update Cloudflare Access wizard prompts
- read Cloudflare credentials from hyphenated env vars too
- document mapping of env vars to header names

### Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841cbcda9488327ae4a3ebc1479b84a