### PR TITLE
Auto-login to OpenBB

### DIFF
--- a/CORE_ENHANCEMENT_SUMMARY.md
+++ b/CORE_ENHANCEMENT_SUMMARY.md
@@ -91,7 +91,7 @@ def fetch_and_compile(...):
 
 # New approach
 def fetch_and_compile(...):
-    obb = _get_openbb()
+    obb = get_openbb()
     rutils.fetch_profile(...)
     rutils.fetch_price_history(...)
     rutils.fetch_financial_statements(...)

--- a/README.md
+++ b/README.md
@@ -47,7 +47,8 @@ OPENBB_TOKEN=your-openbb-token
 FMP_API_KEY=your-fmp-key
 OUTPUT_DIR=output
 ```
-See [docs/configuration.md](docs/configuration.md) for all options.
+The token is used by `modules.utils.get_openbb()` to authenticate with the OpenBB Hub
+whenever data is requested. See [docs/configuration.md](docs/configuration.md) for all options.
 
 ## Quickstart
 Run the interactive menu:

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -26,7 +26,8 @@ OUTPUT_DIR=output
 To obtain an OpenBB API token visit the
 [OpenBB documentation](https://docs.openbb.co/platform/getting_started/api_requests)
 and sign up for an account. Once acquired, run the **OpenBB API Token** wizard
-inside the Settings Manager to store the token. The Settings Manager also
+inside the Settings Manager to store the token. The `get_openbb()` helper uses this
+token to log in whenever OpenBB data is requested. The Settings Manager also
  provides wizards for configuring your **Directus connection** and **Notes
  directory**. Another wizard sets the **Output Directory** used for reports.
  A **Cloudflare Access** wizard stores the `CF_ACCESS_CLIENT_ID` and

--- a/modules/data/compare.py
+++ b/modules/data/compare.py
@@ -6,6 +6,7 @@ from typing import Dict, Tuple
 
 import pandas as pd
 import yfinance as yf
+from modules.utils import get_openbb
 
 logger = logging.getLogger(__name__)
 
@@ -15,7 +16,7 @@ ESSENTIAL_COLS = ["longName", "sector", "industry", "marketCap", "website"]
 def fetch_profile_openbb(symbol: str) -> pd.DataFrame:
     """Fetch company profile via OpenBB. Returns empty DataFrame on error."""
     try:
-        from openbb import obb  # imported lazily to avoid heavy startup if unused
+        obb = get_openbb()
         obj = obb.equity.profile(symbol=symbol)
         df = obj.to_df()
         return df

--- a/modules/generate_report/report_generator.py
+++ b/modules/generate_report/report_generator.py
@@ -15,17 +15,17 @@ import sys
 
 from modules.generate_report import report_utils as rutils
 from modules.generate_report.utils import iso_timestamp_utc
+from modules.utils import get_openbb
 
-# Delay heavy OpenBB import until needed
+# Lazily loaded OpenBB module for test monkeypatching
 obb = None
 
 
 def _get_openbb():
-    """Load OpenBB lazily and return the module."""
+    """Return cached OpenBB module logging in on first use."""
     global obb
     if obb is None:
-        from openbb import obb as _obb
-        obb = _obb
+        obb = get_openbb()
     return obb
 
 

--- a/modules/utils/__init__.py
+++ b/modules/utils/__init__.py
@@ -16,6 +16,7 @@ from .data_utils import (
 from .excel_utils import col_to_letter, write_table
 from .math_utils import moving_average, percentage_change
 from .progress_utils import progress_iter
+from .openbb_utils import get_openbb
 
 __all__ = [
     "strip_timezones",
@@ -27,4 +28,5 @@ __all__ = [
     "moving_average",
     "percentage_change",
     "progress_iter",
+    "get_openbb",
 ]

--- a/modules/utils/openbb_utils.py
+++ b/modules/utils/openbb_utils.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+"""Utility functions for accessing the OpenBB Platform."""
+
+import os
+
+
+_obb = None
+_logged_in = False
+
+
+def get_openbb():
+    """Return OpenBB module ensuring login via ``OPENBB_TOKEN`` if available."""
+    global _obb, _logged_in
+    if _obb is None:
+        from openbb import obb as _module
+        _obb = _module
+    if not _logged_in:
+        token = os.getenv("OPENBB_TOKEN")
+        if token:
+            try:
+                _obb.account.login(pat=token)
+                _logged_in = True
+            except Exception as exc:  # pragma: no cover - network/login error
+                print(f"Warning: OpenBB login failed: {exc}")
+        else:
+            print("OPENBB_TOKEN environment variable not set; skipping OpenBB login.")
+    return _obb


### PR DESCRIPTION
## Summary
- add `modules.utils.get_openbb` helper that logs in using `OPENBB_TOKEN`
- ensure report generator and compare utilities use `_get_openbb`
- document new helper usage in README and configuration docs
- update core enhancement notes

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841d0a0417c83279a594dab5dd30baf