### PR TITLE
Refactor data helpers

### DIFF
--- a/modules/data/compare.py
+++ b/modules/data/compare.py
@@ -57,6 +57,16 @@ def diff_dict(d1: Dict, d2: Dict) -> Dict[str, Tuple]:
     return out
 
 
+def _show_differences(symbol: str, diffs: Dict[str, Tuple]) -> None:
+    """Print human-readable differences between profile dictionaries."""
+    if diffs:
+        print(f"\nDifferences for {symbol}:")
+        for k, (v1, v2) in diffs.items():
+            print(f"  {k}: OpenBB='{v1}'  vs  yfinance='{v2}'")
+    else:
+        print(f"No differences detected for {symbol} on essential fields.")
+
+
 def interactive_profile(symbol: str) -> pd.DataFrame:
     """Fetch profile from OpenBB and yfinance, compare and prompt user to choose."""
     obb_df = fetch_profile_openbb(symbol)
@@ -78,13 +88,11 @@ def interactive_profile(symbol: str) -> pd.DataFrame:
     # Both have data, compare
     d1 = obb_df.iloc[0].to_dict()
     d2 = yf_df.iloc[0].to_dict()
-    diffs = diff_dict({k: d1.get(k) for k in ESSENTIAL_COLS}, {k: d2.get(k) for k in ESSENTIAL_COLS})
-    if diffs:
-        print(f"\nDifferences for {symbol}:")
-        for k, (v1, v2) in diffs.items():
-            print(f"  {k}: OpenBB='{v1}'  vs  yfinance='{v2}'")
-    else:
-        print(f"No differences detected for {symbol} on essential fields.")
+    diffs = diff_dict(
+        {k: d1.get(k) for k in ESSENTIAL_COLS},
+        {k: d2.get(k) for k in ESSENTIAL_COLS},
+    )
+    _show_differences(symbol, diffs)
 
     choice = input("Use OpenBB data (O) or yfinance data (Y)? [O/Y]: ").strip().lower()
     if choice == 'y':

--- a/modules/data/directus_mapper.py
+++ b/modules/data/directus_mapper.py
@@ -1,4 +1,4 @@
-
+"""Helpers to map local data fields to Directus collection fields."""
 
 import json
 import logging
@@ -22,17 +22,22 @@ def load_field_map() -> Dict[str, Any]:
         with open(MAP_FILE, "r", encoding="utf-8") as f:
             data = json.load(f)
         if "collections" not in data:
-            converted = {"collections": {}}
-            for col, fields in data.items():
-                converted["collections"][col] = {
-                    "fields": {
-                        name: {"type": None, "mapped_to": dest}
-                        for name, dest in fields.items()
-                    }
-                }
-            return converted
+            return _convert_legacy_format(data)
         return data
     return {"collections": {}}
+
+
+def _convert_legacy_format(data: Dict[str, Any]) -> Dict[str, Any]:
+    """Return mapping converted from legacy ``collection -> field`` format."""
+    converted = {"collections": {}}
+    for col, fields in data.items():
+        converted["collections"][col] = {
+            "fields": {
+                name: {"type": None, "mapped_to": dest}
+                for name, dest in fields.items()
+            }
+        }
+    return converted
 
 
 def save_field_map(mapping: Dict[str, Any]) -> None:

--- a/modules/data/fetching.py
+++ b/modules/data/fetching.py
@@ -24,6 +24,7 @@ BASIC_FIELDS = [
 
 
 FMP_PROFILE_URL = "https://financialmodelingprep.com/api/v3/profile/{symbol}"
+FMP_TIMEOUT = 10
 
 
 def _parse_yf_info(info: dict, ticker: str) -> dict:
@@ -41,9 +42,9 @@ def _parse_yf_info(info: dict, ticker: str) -> dict:
 
 
 def _fetch_from_fmp(ticker: str) -> dict:
-    """Return BASIC_FIELDS dict using FMP profile endpoint."""
+    """Return BASIC_FIELDS dict using the FMP profile endpoint."""
     url = add_fmp_api_key(FMP_PROFILE_URL.format(symbol=ticker))
-    resp = requests.get(url, timeout=10)
+    resp = requests.get(url, timeout=FMP_TIMEOUT)
     resp.raise_for_status()
     data = resp.json()
     if not data or not isinstance(data, list):

--- a/modules/data/term_mapper.py
+++ b/modules/data/term_mapper.py
@@ -1,4 +1,4 @@
-
+"""Utilities to normalize sector and industry terminology."""
 
 import json
 import os


### PR DESCRIPTION
## Summary
- clean up Directus client helpers and reuse data extraction
- clarify compare profile display logic
- add fallback constants and refactor mapping converter
- document term mapper and fetching helpers

## Testing
- `pytest -q -W once`

------
https://chatgpt.com/codex/tasks/task_e_6841f2d715a08327ac526cac2e549f76