### PR TITLE
Refactor compare module for readability

### DIFF
--- a/agent.md
+++ b/agent.md
@@ -1,0 +1,15 @@
+
+## Recent Findings
+
+```
+........................................................................ [ 61%]
+..............................................                           [100%]
+=============================== warnings summary ===============================
+tests/test_portfolio_manager.py::test_add_new_ticker_with_nas_present
+tests/test_portfolio_manager.py::test_add_ticker_to_all_na_column
+  /workspace/Fundalyze/modules/management/portfolio_manager/portfolio_manager.py:89: FutureWarning: The behavior of DataFrame concatenation with empty or all-NA entries is deprecated. In a future version, this will no longer exclude empty or all-NA columns when determining the result dtypes. To retain the old behavior, exclude the relevant entries before the concat operation.
+    return pd.concat([df, new_row], ignore_index=True)
+
+-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
+118 passed, 2 warnings in 33.79s
+```


### PR DESCRIPTION
## Summary
- refactor `compare` utility for readability and structure
- introduce `compare_profiles` helper
- tidy printing and add clearer docstrings
- use typing hints and constants for prompts

## Testing
- `pytest -q -W once`

------
https://chatgpt.com/codex/tasks/task_e_6841f64e8af483279f597b599785e874