### PR TITLE
Refactor term mapper utilities

### DIFF
--- a/agent.md
+++ b/agent.md
@@ -1,0 +1,30 @@
+
+## Recent Findings
+
+```
+........................................................................ [ 61%]
+..............................................                           [100%]
+=============================== warnings summary ===============================
+tests/test_portfolio_manager.py::test_add_new_ticker_with_nas_present
+tests/test_portfolio_manager.py::test_add_ticker_to_all_na_column
+  /workspace/Fundalyze/modules/management/portfolio_manager/portfolio_manager.py:89: FutureWarning: The behavior of DataFrame concatenation with empty or all-NA entries is deprecated. In a future version, this will no longer exclude empty or all-NA columns when determining the result dtypes. To retain the old behavior, exclude the relevant entries before the concat operation.
+    return pd.concat([df, new_row], ignore_index=True)
+
+-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
+118 passed, 2 warnings in 32.35s
+```
+
+### After Refactor
+
+```
+........................................................................ [ 61%]
+..............................................                           [100%]
+=============================== warnings summary ===============================
+tests/test_portfolio_manager.py::test_add_new_ticker_with_nas_present
+tests/test_portfolio_manager.py::test_add_ticker_to_all_na_column
+  /workspace/Fundalyze/modules/management/portfolio_manager/portfolio_manager.py:89: FutureWarning: The behavior of DataFrame concatenation with empty or all-NA entries is deprecated. In a future version, this will no longer exclude empty or all-NA columns when determining the result dtypes. To retain the old behavior, exclude the relevant entries before the concat operation.
+    return pd.concat([df, new_row], ignore_index=True)
+
+-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
+118 passed, 2 warnings in 28.75s
+```

--- a/modules/data/term_mapper.py
+++ b/modules/data/term_mapper.py
@@ -1,6 +1,7 @@
 """Utilities to normalize sector and industry terminology."""
 
 import json
+import logging
 import os
 from pathlib import Path
 from typing import Dict, List, Optional
@@ -9,30 +10,33 @@ from modules.config_utils import load_settings  # noqa: E402
 
 load_settings()
 
+logger = logging.getLogger(__name__)
+
 try:
     import openai
-except Exception:
+except Exception:  # pragma: no cover - optional dependency
     openai = None
 
 
 # Configuration file lives in the project's top-level `config/` directory
 PROJECT_ROOT = Path(__file__).resolve().parents[2]
-MAPPING_FILE = PROJECT_ROOT / 'config' / 'term_mapping.json'
+MAPPING_FILE = PROJECT_ROOT / "config" / "term_mapping.json"
+
+OPENAI_MODEL = "gpt-3.5-turbo"
+UNKNOWN_RESPONSE = "Unknown"
 
 
 def load_mapping() -> Dict[str, List[str]]:
     """Return term mapping dictionary from :data:`MAPPING_FILE`."""
     if not MAPPING_FILE.is_file():
         return {}
-    with open(MAPPING_FILE, 'r', encoding='utf-8') as f:
-        return json.load(f)
+    return json.loads(MAPPING_FILE.read_text(encoding="utf-8"))
 
 
-def save_mapping(mapping: Dict[str, List[str]]):
+def save_mapping(mapping: Dict[str, List[str]]) -> None:
     """Write ``mapping`` to :data:`MAPPING_FILE`."""
     MAPPING_FILE.parent.mkdir(parents=True, exist_ok=True)
-    with open(MAPPING_FILE, 'w', encoding='utf-8') as f:
-        json.dump(mapping, f, indent=2)
+    MAPPING_FILE.write_text(json.dumps(mapping, indent=2), encoding="utf-8")
 
 
 def _normalize(text: str) -> str:
@@ -40,7 +44,39 @@ def _normalize(text: str) -> str:
     return text.strip().lower()
 
 
-def add_alias(canonical: str, alias: str):
+def _find_direct_match(mapping: Dict[str, List[str]], norm: str) -> Optional[str]:
+    """Return canonical term if ``norm`` matches a canonical or alias."""
+    for canonical, aliases in mapping.items():
+        if norm == _normalize(canonical) or norm in map(_normalize, aliases):
+            return canonical
+    return None
+
+
+def _confirm_suggestion(term: str, suggestion: str) -> bool:
+    """Return True if user confirms mapping ``term`` to ``suggestion``."""
+    resp = input(f"Map '{term}' to '{suggestion}'? (Y/n): ").strip().lower()
+    return resp in ("", "y", "yes")
+
+
+def _manual_selection(term: str, mapping: Dict[str, List[str]]) -> Optional[str]:
+    """Interactively choose or create a canonical term for ``term``."""
+    print(f"\nUnknown term: '{term}'.")
+    if mapping:
+        print("Available canonical terms:")
+        canonicals = list(mapping.keys())
+        for idx, canonical in enumerate(canonicals, start=1):
+            print(f"  {idx}) {canonical}")
+        print(f"  {len(canonicals) + 1}) Create new canonical term")
+        choice = input(f"Select 1-{len(canonicals) + 1}: ").strip()
+        if choice.isdigit():
+            idx = int(choice)
+            if 1 <= idx <= len(canonicals):
+                return canonicals[idx - 1]
+    canonical = input("Enter new canonical term: ").strip()
+    return canonical or None
+
+
+def add_alias(canonical: str, alias: str) -> None:
     """Persist ``alias`` as an alternative spelling for ``canonical``."""
     mapping = load_mapping()
     canonical_norm = canonical.strip()
@@ -56,25 +92,25 @@ def add_alias(canonical: str, alias: str):
 
 def _suggest_with_openai(term: str, options: List[str]) -> Optional[str]:
     """Return best matching option suggested by OpenAI or ``None``."""
-    if openai is None or not os.getenv('OPENAI_API_KEY'):
+    if openai is None or not os.getenv("OPENAI_API_KEY"):
         return None
     try:
         client = openai.OpenAI(api_key=os.getenv("OPENAI_API_KEY"))
         prompt = (
             "You are an assistant that maps financial sector or industry terms to a canonical term. "
             f"Given the term '{term}', choose the best match from the following options: {', '.join(options)}. "
-            "Respond with only the best matching option or 'Unknown'."
+            f"Respond with only the best matching option or '{UNKNOWN_RESPONSE}'."
         )
         response = client.chat.completions.create(
-            model="gpt-3.5-turbo",
+            model=OPENAI_MODEL,
             messages=[{"role": "user", "content": prompt}],
             max_tokens=6,
         )
         choice = response.choices[0].message.content.strip()
-        if choice and choice != 'Unknown':
+        if choice and choice != UNKNOWN_RESPONSE:
             return choice
-    except Exception:
-        return None
+    except Exception as exc:  # pragma: no cover - network errors nondeterministic
+        logger.error("OpenAI suggestion failed: %s", exc)
     return None
 
 
@@ -87,37 +123,22 @@ def resolve_term(term: str) -> str:
     """
     if not term:
         return term
+
     mapping = load_mapping()
     norm = _normalize(term)
-    # direct match
-    for canonical, aliases in mapping.items():
-        if norm == _normalize(canonical) or norm in [_normalize(a) for a in aliases]:
-            return canonical
-    # not found; try openai suggestion
+
+    canonical = _find_direct_match(mapping, norm)
+    if canonical:
+        return canonical
+
     suggestion = _suggest_with_openai(term, list(mapping.keys()))
-    if suggestion:
-        resp = input(f"Map '{term}' to '{suggestion}'? (Y/n): ").strip().lower()
-        if resp in ('', 'y', 'yes'):
-            add_alias(suggestion, term)
-            return suggestion
-    # manual selection
-    print(f"\nUnknown term: '{term}'.")
-    if mapping:
-        print("Available canonical terms:")
-        canonicals = list(mapping.keys())
-        for idx, c in enumerate(canonicals, start=1):
-            print(f"  {idx}) {c}")
-        print(f"  {len(canonicals)+1}) Create new canonical term")
-        choice = input(f"Select 1-{len(canonicals)+1}: ").strip()
-        if choice.isdigit():
-            idx = int(choice)
-            if 1 <= idx <= len(canonicals):
-                canonical = canonicals[idx-1]
-                add_alias(canonical, term)
-                return canonical
-    # create new canonical
-    canonical = input("Enter new canonical term: ").strip()
+    if suggestion and _confirm_suggestion(term, suggestion):
+        add_alias(suggestion, term)
+        return suggestion
+
+    canonical = _manual_selection(term, mapping)
     if canonical:
         add_alias(canonical, term)
         return canonical
+
     return term


### PR DESCRIPTION
## Summary
- improve readability and logging in term mapper
- split matching/interaction logic into helper functions
- use pathlib for file writes/reads
- document new test run

## Testing
- `pytest -q -W once`

------
https://chatgpt.com/codex/tasks/task_e_6841f71a64fc83279c7f4656f56bb43f