### PR TITLE
Refactor JSON schema with reusable definitions

### DIFF
--- a/agent.md
+++ b/agent.md
@@ -24,3 +24,16 @@ tests/test_portfolio_manager.py::test_add_ticker_to_all_na_column
 
 -- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
 118 passed, 2 warnings in 38.58s
+
+## Recent Findings
+
+........................................................................ [ 61%]
+..............................................                           [100%]
+=============================== warnings summary ===============================
+tests/test_portfolio_manager.py::test_add_new_ticker_with_nas_present
+tests/test_portfolio_manager.py::test_add_ticker_to_all_na_column
+  /workspace/Fundalyze/modules/management/portfolio_manager/portfolio_manager.py:89: FutureWarning: The behavior of DataFrame concatenation with empty or all-NA entries is deprecated. In a future version, this will no longer exclude empty or all-NA columns when determining the result dtypes. To retain the old behavior, exclude the relevant entries before the concat operation.
+    return pd.concat([df, new_row], ignore_index=True)
+
+-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
+118 passed, 2 warnings in 28.18s

--- a/config/directus_field_map.schema.json
+++ b/config/directus_field_map.schema.json
@@ -6,31 +6,35 @@
     "collections": {
       "description": "Dictionary keyed by Directus collection name.",
       "type": "object",
-      "additionalProperties": {
-        "type": "object",
-        "properties": {
-          "fields": {
-            "description": "Mapping of local column names to Directus fields.",
-            "type": "object",
-            "additionalProperties": {
-              "type": "object",
-              "properties": {
-                "type": {
-                  "description": "Directus data type, may be null",
-                  "type": ["string", "null"]
-                },
-                "mapped_to": {
-                  "description": "Target field name in Directus",
-                  "type": "string"
-                }
-              },
-              "required": ["mapped_to"]
-            }
-          }
-        },
-        "required": ["fields"]
-      }
+      "additionalProperties": { "$ref": "#/$defs/collection" }
     }
   },
-  "required": ["collections"]
+  "required": ["collections"],
+  "$defs": {
+    "collection": {
+      "type": "object",
+      "properties": {
+        "fields": {
+          "description": "Mapping of local column names to Directus fields.",
+          "type": "object",
+          "additionalProperties": { "$ref": "#/$defs/field" }
+        }
+      },
+      "required": ["fields"]
+    },
+    "field": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "description": "Directus data type, may be null",
+          "type": ["string", "null"]
+        },
+        "mapped_to": {
+          "description": "Target field name in Directus",
+          "type": "string"
+        }
+      },
+      "required": ["mapped_to"]
+    }
+  }
 }


### PR DESCRIPTION
### Summary
- improve the structure of `directus_field_map.schema.json`
- record latest test results in `agent.md`

### Testing
- `pytest -q -W once`

------
https://chatgpt.com/codex/tasks/task_e_6841fa41691c8327998d8256bd954610