### PR TITLE
Improve finance_api.yaml readability

### DIFF
--- a/agent.md
+++ b/agent.md
@@ -24,3 +24,33 @@ tests/test_portfolio_manager.py::test_add_ticker_to_all_na_column
 
 -- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
 118 passed, 2 warnings in 38.58s
+
+## Recent Findings
+
+```
+........................................................................ [ 61%]
+..............................................                           [100%]
+=============================== warnings summary ===============================
+tests/test_portfolio_manager.py::test_add_new_ticker_with_nas_present
+tests/test_portfolio_manager.py::test_add_ticker_to_all_na_column
+  /workspace/Fundalyze/modules/management/portfolio_manager/portfolio_manager.py:89: FutureWarning: The behavior of DataFrame concatenation with empty or all-NA entries is deprecated. In a future version, this will no longer exclude empty or all-NA columns when determining the result dtypes. To retain the old behavior, exclude the relevant entries before the concat operation.
+    return pd.concat([df, new_row], ignore_index=True)
+
+-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
+118 passed, 2 warnings in 30.39s
+```
+
+## Recent Findings
+
+```
+........................................................................ [ 61%]
+..............................................                           [100%]
+=============================== warnings summary ===============================
+tests/test_portfolio_manager.py::test_add_new_ticker_with_nas_present
+tests/test_portfolio_manager.py::test_add_ticker_to_all_na_column
+  /workspace/Fundalyze/modules/management/portfolio_manager/portfolio_manager.py:89: FutureWarning: The behavior of DataFrame concatenation with empty or all-NA entries is deprecated. In a future version, this will no longer exclude empty or all-NA columns when determining the result dtypes. To retain the old behavior, exclude the relevant entries before the concat operation.
+    return pd.concat([df, new_row], ignore_index=True)
+
+-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
+118 passed, 2 warnings in 26.83s
+```

--- a/config/finance_api.yaml
+++ b/config/finance_api.yaml
@@ -1,12 +1,17 @@
-# Example configuration for an optional finance API
-# base_url  - Root API endpoint
-# api_key   - Authentication token
-# endpoints - Paths for various resources
-#   profile: Path to company profile endpoint (uses {symbol})
-#   prices:  Path to historical prices endpoint
-#
-base_url: https://example.com/api
-api_key: your-api-key
+# Configuration for an optional finance API integration.
+# Replace the example values as needed.
+
+# Root endpoint for API requests.
+base_url: "https://example.com/api"
+
+# Authentication token (leave blank if the API doesn't require one).
+api_key: "your-api-key"
+
+# Endpoint templates used by helper scripts.
+# Placeholders:
+#   {symbol} - ticker symbol
+#   {period} - historical period (e.g., "1y").
 endpoints:
-  profile: /v1/profile/{symbol}
-  prices: /v1/prices/{symbol}?period={period}
+  profile: "/v1/profile/{symbol}"                # Company profile endpoint.
+  prices:  "/v1/prices/{symbol}?period={period}" # Historical prices endpoint.
+


### PR DESCRIPTION
## Summary
- clarify finance_api configuration comments for easier customization
- update automated agent findings

## Testing
- `pytest -q -W once`

------
https://chatgpt.com/codex/tasks/task_e_6841fa90afec83278f3c88f245f518fd