### PR TITLE
Add configurable finance API client

### DIFF
--- a/agent.md
+++ b/agent.md
@@ -24,3 +24,18 @@ tests/test_portfolio_manager.py::test_add_ticker_to_all_na_column
 
 -- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
 118 passed, 2 warnings in 38.58s
+
+## Recent Findings
+
+```
+........................................................................ [ 59%]
+.................................................                        [100%]
+=============================== warnings summary ===============================
+tests/test_portfolio_manager.py::test_add_new_ticker_with_nas_present
+tests/test_portfolio_manager.py::test_add_ticker_to_all_na_column
+  /workspace/Fundalyze/modules/management/portfolio_manager/portfolio_manager.py:89: FutureWarning: The behavior of DataFrame concatenation with empty or all-NA entries is deprecated. In a future version, this will no longer exclude empty or all-NA columns when determining the result dtypes. To retain the old behavior, exclude the relevant entries before the concat operation.
+    return pd.concat([df, new_row], ignore_index=True)
+
+-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
+121 passed, 2 warnings in 41.56s
+```

--- a/modules/data/__init__.py
+++ b/modules/data/__init__.py
@@ -6,6 +6,7 @@ them directly.  All submodules remain importable on their own.
 """
 
 from .fetching import fetch_basic_stock_data, BASIC_FIELDS
+from .finance_api import FinanceAPIClient, FinanceAPIConfig
 from .directus_client import (
     list_collections,
     list_fields,
@@ -49,5 +50,7 @@ __all__ = [
     "prepare_records",
     "interactive_prepare_records",
     "refresh_field_map",
+    "FinanceAPIClient",
+    "FinanceAPIConfig",
     "ensure_field_mapping",
 ]

--- a/modules/data/finance_api.py
+++ b/modules/data/finance_api.py
@@ -1,0 +1,100 @@
+"""Client for custom finance API configured via ``finance_api.yaml``.
+
+The optional configuration file ``config/finance_api.yaml`` defines the base
+URL, API key, and endpoint paths for retrieving financial data from a custom
+source. :class:`FinanceAPIClient` provides a small wrapper around ``requests``
+for easy access to these endpoints.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+import requests
+import yaml
+
+from modules.config_utils import CONFIG_DIR
+
+DEFAULT_TIMEOUT = 10
+CONFIG_FILE = CONFIG_DIR / "finance_api.yaml"
+
+
+@dataclass
+class FinanceAPIConfig:
+    """Configuration options for :class:`FinanceAPIClient`."""
+
+    base_url: str
+    api_key: Optional[str] = None
+    endpoints: Dict[str, str] = field(default_factory=dict)
+
+    @classmethod
+    def load(cls, path: Path | None = None) -> "FinanceAPIConfig":
+        """Load configuration from ``path`` or the default location.
+
+        Parameters
+        ----------
+        path:
+            Optional path to a YAML file. If omitted, ``config/finance_api.yaml``
+            is used.
+
+        Returns
+        -------
+        FinanceAPIConfig
+            Parsed configuration object.
+        """
+
+        cfg_path = path or CONFIG_FILE
+        if not cfg_path.is_file():
+            raise FileNotFoundError(f"Finance API config not found: {cfg_path}")
+        with open(cfg_path, "r", encoding="utf-8") as fh:
+            data = yaml.safe_load(fh) or {}
+        return cls(
+            base_url=str(data.get("base_url", "")),
+            api_key=data.get("api_key"),
+            endpoints=data.get("endpoints", {}) or {},
+        )
+
+
+class FinanceAPIClient:
+    """Simple client for a user-configured finance API."""
+
+    def __init__(self, config: FinanceAPIConfig, timeout: int = DEFAULT_TIMEOUT) -> None:
+        self.config = config
+        self.timeout = timeout
+
+    # ------------------------------------------------------------------
+    # internal helpers
+    # ------------------------------------------------------------------
+    def _build_url(self, endpoint: str, **params: Any) -> str:
+        base = self.config.base_url.rstrip("/")
+        path = endpoint.format(**params).lstrip("/")
+        url = f"{base}/{path}"
+        if self.config.api_key:
+            sep = "&" if "?" in url else "?"
+            url = f"{url}{sep}apikey={self.config.api_key}"
+        return url
+
+    def _get(self, endpoint_key: str, **params: Any) -> requests.Response:
+        if endpoint_key not in self.config.endpoints:
+            raise KeyError(f"Unknown endpoint '{endpoint_key}'")
+        url = self._build_url(self.config.endpoints[endpoint_key], **params)
+        resp = requests.get(url, timeout=self.timeout)
+        resp.raise_for_status()
+        return resp
+
+    # ------------------------------------------------------------------
+    # public API methods
+    # ------------------------------------------------------------------
+    def get_profile(self, symbol: str) -> Dict[str, Any]:
+        """Return company profile information as JSON."""
+
+        resp = self._get("profile", symbol=symbol)
+        return resp.json()
+
+    def get_prices(self, symbol: str, period: str) -> Dict[str, Any]:
+        """Return price history as JSON."""
+
+        resp = self._get("prices", symbol=symbol, period=period)
+        return resp.json()

--- a/tests/test_finance_api.py
+++ b/tests/test_finance_api.py
@@ -1,0 +1,53 @@
+"""Tests for FinanceAPIConfig and FinanceAPIClient."""
+
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from modules.data.finance_api import FinanceAPIConfig, FinanceAPIClient
+
+
+def test_config_load(tmp_path: Path) -> None:
+    cfg_file = tmp_path / "finance_api.yaml"
+    cfg_file.write_text(
+        """
+base_url: https://example.com/api
+api_key: token123
+endpoints:
+  profile: /p/{symbol}
+"""
+    )
+
+    cfg = FinanceAPIConfig.load(cfg_file)
+    assert cfg.base_url == "https://example.com/api"
+    assert cfg.api_key == "token123"
+    assert cfg.endpoints["profile"] == "/p/{symbol}"
+
+
+def test_client_builds_url_and_fetches(monkeypatch):
+    cfg = FinanceAPIConfig(
+        base_url="https://api.test", api_key="ABC", endpoints={"profile": "/pro/{symbol}"}
+    )
+    called = {}
+
+    def fake_get(url, timeout):
+        called["url"] = url
+        called["timeout"] = timeout
+        return SimpleNamespace(json=lambda: {"ok": True}, raise_for_status=lambda: None)
+
+    monkeypatch.setattr("modules.data.finance_api.requests.get", fake_get)
+    client = FinanceAPIClient(cfg, timeout=5)
+    result = client.get_profile("XYZ")
+
+    assert result == {"ok": True}
+    assert called["url"] == "https://api.test/pro/XYZ?apikey=ABC"
+    assert called["timeout"] == 5
+
+
+def test_missing_endpoint():
+    cfg = FinanceAPIConfig(base_url="x", endpoints={})
+    client = FinanceAPIClient(cfg)
+    with pytest.raises(KeyError):
+        client.get_profile("ABC")
+


### PR DESCRIPTION
## Summary
- implement `FinanceAPIConfig` and `FinanceAPIClient`
- expose new client in `modules.data` package
- add unit tests for the client

## Testing
- `pytest -q -W once`

------
https://chatgpt.com/codex/tasks/task_e_6841fa6c7df0832793b8bd175becd000