### PR TITLE
Refactor term mapping schema

### DIFF
--- a/agent.md
+++ b/agent.md
@@ -24,3 +24,33 @@ tests/test_portfolio_manager.py::test_add_ticker_to_all_na_column
 
 -- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
 118 passed, 2 warnings in 38.58s
+
+## Recent Findings
+
+```
+........................................................................ [ 61%]
+..............................................                           [100%]
+=============================== warnings summary ===============================
+tests/test_portfolio_manager.py::test_add_new_ticker_with_nas_present
+tests/test_portfolio_manager.py::test_add_ticker_to_all_na_column
+  /workspace/Fundalyze/modules/management/portfolio_manager/portfolio_manager.py:89: FutureWarning: The behavior of DataFrame concatenation with empty or all-NA entries is deprecated. In a future version, this will no longer exclude empty or all-NA columns when determining the result dtypes. To retain the old behavior, exclude the relevant entries before the concat operation.
+    return pd.concat([df, new_row], ignore_index=True)
+
+-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
+118 passed, 2 warnings in 32.06s
+```
+
+## Recent Findings
+
+```
+........................................................................ [ 61%]
+..............................................                           [100%]
+=============================== warnings summary ===============================
+tests/test_portfolio_manager.py::test_add_new_ticker_with_nas_present
+tests/test_portfolio_manager.py::test_add_ticker_to_all_na_column
+  /workspace/Fundalyze/modules/management/portfolio_manager/portfolio_manager.py:89: FutureWarning: The behavior of DataFrame concatenation with empty or all-NA entries is deprecated. In a future version, this will no longer exclude empty or all-NA columns when determining the result dtypes. To retain the old behavior, exclude the relevant entries before the concat operation.
+    return pd.concat([df, new_row], ignore_index=True)
+
+-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
+118 passed, 2 warnings in 32.07s
+```

--- a/config/term_mapping.schema.json
+++ b/config/term_mapping.schema.json
@@ -1,10 +1,17 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "title": "Sector and Industry Term Mapping",
+  "description": "Maps canonical sector or industry names to lists of known aliases used across APIs.",
   "type": "object",
-  "description": "Maps canonical sector or industry names to a list of aliases used across APIs.",
-  "additionalProperties": {
-    "type": "array",
-    "items": {"type": "string"}
-  }
+  "patternProperties": {
+    "^.+$": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "minLength": 1
+      },
+      "minItems": 1
+    }
+  },
+  "additionalProperties": false
 }


### PR DESCRIPTION
## Summary
- enforce constraints in `config/term_mapping.schema.json` for better validation
- record latest test results

## Testing
- `pytest -q -W once`

------
https://chatgpt.com/codex/tasks/task_e_6841fad43f488327900bd74fd18f1c0a