### PR TITLE
Refactor term mapping utilities

### DIFF
--- a/agent.md
+++ b/agent.md
@@ -24,3 +24,18 @@ tests/test_portfolio_manager.py::test_add_ticker_to_all_na_column
 
 -- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
 118 passed, 2 warnings in 38.58s
+
+## Recent Findings
+
+```
+........................................................................ [ 61%]
+..............................................                           [100%]
+=============================== warnings summary ===============================
+tests/test_portfolio_manager.py::test_add_new_ticker_with_nas_present
+tests/test_portfolio_manager.py::test_add_ticker_to_all_na_column
+  /workspace/Fundalyze/modules/management/portfolio_manager/portfolio_manager.py:89: FutureWarning: The behavior of DataFrame concatenation with empty or all-NA entries is deprecated. In a future version, this will no longer exclude empty or all-NA columns when determining the result dtypes. To retain the old behavior, exclude the relevant entries before the concat operation.
+    return pd.concat([df, new_row], ignore_index=True)
+
+-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
+118 passed, 2 warnings in 31.38s
+```

--- a/config/term_mapping.json
+++ b/config/term_mapping.json
@@ -1,12 +1,11 @@
 {
-  "Technology": [
-    "Tech",
-    "Information Technology",
-    "IT",
-    "Conglomerates",
-    "Consumer Electronics",
-    "Communication Services",
-    "Internet Content & Information"
+  "Aerospace & Defense": [],
+  "Consumer Discretionary": [
+    "Auto Manufacturers",
+    "Consumer Cyclical"
+  ],
+  "Consumer Staples": [
+    "Consumer Defensive"
   ],
   "Financials": [
     "Finance",
@@ -16,18 +15,17 @@
     "Health Care",
     "Medical"
   ],
-  "Consumer Discretionary": [
-    "Consumer Cyclical",
-    "Auto Manufacturers"
-  ],
-  "Consumer Staples": [
-    "Consumer Defensive"
-  ],
   "Industrials": [
-    "Industrials",
     "Specialty Industrial Machinery"
   ],
-  "Aerospace & Defense": [
-    "Aerospace & Defense"
+  "Technology": [
+    "Communication Services",
+    "Conglomerates",
+    "Consumer Electronics",
+    "IT",
+    "Information Technology",
+    "Internet Content & Information",
+    "Tech"
   ]
 }
+


### PR DESCRIPTION
## Summary
- sort `term_mapping.json` for easier maintenance
- clean and document `term_mapper` helpers
- ensure saved mappings are consistently ordered

## Testing
- `pytest -q -W once`

------
https://chatgpt.com/codex/tasks/task_e_6841fab01ba88327973dccb69d2640ca