### PR TITLE
Add refactor prompt template

### DIFF
--- a/agent.md
+++ b/agent.md
@@ -24,3 +24,33 @@ tests/test_portfolio_manager.py::test_add_ticker_to_all_na_column
 
 -- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
 118 passed, 2 warnings in 38.58s
+
+## Recent Findings
+
+```
+........................................................................ [ 61%]
+..............................................                           [100%]
+=============================== warnings summary ===============================
+tests/test_portfolio_manager.py::test_add_new_ticker_with_nas_present
+tests/test_portfolio_manager.py::test_add_ticker_to_all_na_column
+  /workspace/Fundalyze/modules/management/portfolio_manager/portfolio_manager.py:89: FutureWarning: The behavior of DataFrame concatenation with empty or all-NA entries is deprecated. In a future version, this will no longer exclude empty or all-NA columns when determining the result dtypes. To retain the old behavior, exclude the relevant entries before the concat operation.
+    return pd.concat([df, new_row], ignore_index=True)
+
+-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
+118 passed, 2 warnings in 33.40s
+```
+
+## Recent Findings
+
+```
+........................................................................ [ 61%]
+..............................................                           [100%]
+=============================== warnings summary ===============================
+tests/test_portfolio_manager.py::test_add_new_ticker_with_nas_present
+tests/test_portfolio_manager.py::test_add_ticker_to_all_na_column
+  /workspace/Fundalyze/modules/management/portfolio_manager/portfolio_manager.py:89: FutureWarning: The behavior of DataFrame concatenation with empty or all-NA entries is deprecated. In a future version, this will no longer exclude empty or all-NA columns when determining the result dtypes. To retain the old behavior, exclude the relevant entries before the concat operation.
+    return pd.concat([df, new_row], ignore_index=True)
+
+-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
+118 passed, 2 warnings in 27.24s
+```

--- a/docs/build/index.md
+++ b/docs/build/index.md
@@ -6,3 +6,4 @@ Welcome to the generated documentation set.
 - [Script Overview](scripts.md)
 - [API Reference](api_reference.md)
 - [Module Diagrams](module_diagrams.md)
+- [Refactor Prompt Template](refactor_prompt_template.md)

--- a/docs/build/modules.md
+++ b/docs/build/modules.md
@@ -4,11 +4,13 @@ This section summarizes the purpose of each package under `modules/`.
 
 ## Core Packages
 
-- **modules.generate_report** – tools for fetching data and building Excel dashboards.
-- **modules.management** – command-line utilities for maintaining local data files.
-- **modules.data** – helpers for retrieving and mapping data from APIs or Directus.
-- **modules.analytics** – basic data analysis helpers.
-- **modules.utils** – small reusable functions used across the project.
-- **modules.config_utils** – load environment variables and settings.
-- **modules.logging_utils** – configure application logging.
-- **modules.interface** – common CLI UI helpers.
+| Package | Purpose |
+|---------|---------|
+| `modules.generate_report` | Tools for fetching data and building Excel dashboards. |
+| `modules.management` | Command-line utilities for maintaining local data files. |
+| `modules.data` | Helpers for retrieving and mapping data from APIs or Directus. |
+| `modules.analytics` | Basic data analysis helpers. |
+| `modules.utils` | Small reusable functions used across the project. |
+| `modules.config_utils` | Load environment variables and settings. |
+| `modules.logging_utils` | Configure application logging. |
+| `modules.interface` | Common CLI UI helpers. |

--- a/docs/build/refactor_prompt_template.md
+++ b/docs/build/refactor_prompt_template.md
@@ -1,0 +1,27 @@
+# Refactor Prompt Template
+
+## Task
+Refactor Code Module
+
+## Objective
+Improve code quality while preserving all functionality.
+
+## Refactor Guidelines
+- Maintain all original logic and output.
+- Improve readability and structure.
+- Eliminate duplicate logic.
+- Split large functions into smaller, single-purpose functions if beneficial.
+- Add or improve function/class docstrings (Google-style).
+- Use modern Python features (f-strings, type hints, pathlib, etc.).
+- Keep naming consistent and descriptive.
+- Apply consistent error handling and logging patterns.
+- Preserve compatibility with related modules (e.g., config, API clients).
+- Ensure it remains testable and extensible.
+
+## Do NOT
+- Change filenames, function signatures, or input/output behavior.
+- Introduce external dependencies unless explicitly requested.
+
+## Output
+- The refactored code (fully self-contained)
+- A brief summary of key changes (e.g., structure, naming, new functions)


### PR DESCRIPTION
## Summary
- add a `refactor_prompt_template.md` doc under `docs/build`
- convert `docs/build/modules.md` to a table for clarity
- link the refactor template from `docs/build/index.md`
- record the latest test run in `agent.md`

## Testing
- `pytest -q -W once`

------
https://chatgpt.com/codex/tasks/task_e_6841fb9cc0888327b55b783d73cc1071