### PR TITLE
Improve Directus automation and unified data fetcher

### DIFF
--- a/docs/scripts_overview.md
+++ b/docs/scripts_overview.md
@@ -15,7 +15,7 @@ Fundalyze/scripts
 ```
 
 ## main.py
-The primary entry point. Running without arguments launches an interactive menu. You may also supply a subcommand such as `report` or `portfolio` to jump directly to a tool.
+The primary entry point. Running without arguments launches an interactive menu. You may also supply a subcommand such as `report` or `portfolio` to jump directly to a tool. A global `--no-openbb` flag disables OpenBB data fetching for troubleshooting.
 
 **Menu map**
 
@@ -26,7 +26,9 @@ The primary entry point. Running without arguments launches an interactive menu.
 4. Directus Tools      -> Directus helpers
 5. Settings            -> edit configuration
 6. Utilities           -> test runner and profiler
-7. Exit                -> quit
+7. View Portfolio      -> fetch portfolio from Directus
+8. View Profiles       -> show company profiles from Directus
+9. Exit                -> quit
 ```
 
 **Flow chart**

--- a/modules/data/README.md
+++ b/modules/data/README.md
@@ -9,11 +9,15 @@ Helpers for retrieving and normalizing data as well as communicating with a Dire
   if data is incomplete.
 - **`directus_client.py`** – thin REST client used for CRUD operations against a
   Directus server. Credentials are read from `config/.env` and all helpers return
-  `None` on error so offline use is possible.
+  `None` on error so offline use is possible. Includes `create_collection_if_missing`
+  for automated collection setup.
 - **`directus_mapper.py`** – maintains `config/directus_field_map.json` and
   converts local DataFrame columns into the field names expected by Directus.
   `refresh_field_map` queries the server to keep the JSON file up‑to‑date and
   interactive helpers prompt for unmapped columns.
+- **`unified_fetcher.py`** – high level wrapper that pulls company data from
+  OpenBB first and gracefully falls back to yfinance and FMP. Use
+  `fetch_and_store` to push records directly to Directus.
 - **`term_mapper.py`** – resolves sector and industry names to a canonical term
   using a JSON map. When an unknown term is encountered the module optionally
   suggests a mapping via OpenAI and then asks the user for confirmation.

--- a/modules/data/__init__.py
+++ b/modules/data/__init__.py
@@ -13,6 +13,7 @@ from .directus_client import (
     fetch_items_filtered,
     insert_items,
     create_field,
+    create_collection_if_missing,
     directus_request,
     reload_env,
 )
@@ -37,6 +38,7 @@ __all__ = [
     "fetch_items_filtered",
     "insert_items",
     "create_field",
+    "create_collection_if_missing",
     "directus_request",
     "reload_env",
     "load_mapping",

--- a/modules/management/README.md
+++ b/modules/management/README.md
@@ -1,0 +1,9 @@
+# modules.management
+
+Command line utilities for interacting with portfolio data stored in Directus.
+The portfolio manager and group analysis tools read and write directly to
+Directus collections, relying on `modules.data.unified_fetcher` to pull
+company information.
+
+Run `python scripts/main.py portfolio` to manage your holdings or use the
+`--no-openbb` flag to disable OpenBB during data fetches.

--- a/modules/management/portfolio_manager/portfolio_manager.py
+++ b/modules/management/portfolio_manager/portfolio_manager.py
@@ -126,11 +126,11 @@ def prompt_manual_entry(ticker: str) -> dict:
     return data
 
 
-def fetch_from_unified(ticker: str) -> dict:
+def fetch_from_unified(ticker: str, *, use_openbb: bool | None = None) -> dict:
     """Return company data via the unified fetcher."""
     from modules.data.unified_fetcher import fetch_company_data
 
-    data = fetch_company_data(ticker)
+    data = fetch_company_data(ticker, use_openbb=use_openbb)
     if data is None:
         raise ValueError("Data not found")
     return data

--- a/tests/test_unified_fetcher.py
+++ b/tests/test_unified_fetcher.py
@@ -1,0 +1,75 @@
+import pandas as pd
+import pytest
+from modules.data import unified_fetcher as uf
+
+
+def test_openbb_success(monkeypatch):
+    sample = {
+        "Ticker": "AAA",
+        "Name": "Acme",
+        "Sector": "Tech",
+        "Industry": "Software",
+        "Current Price": 1.0,
+        "Market Cap": 2.0,
+        "PE Ratio": pd.NA,
+        "Dividend Yield": 0.0,
+    }
+    monkeypatch.setattr(uf, "_from_openbb", lambda t: sample)
+    monkeypatch.setattr(uf, "fetch_basic_stock_data", lambda t: sample)
+    monkeypatch.setattr(uf, "resolve_term", lambda x: x)
+    result = uf.fetch_company_data("AAA")
+    assert result == sample
+
+
+def test_openbb_partial(monkeypatch):
+    openbb = {
+        "Ticker": "AAA",
+        "Name": "Acme",
+        "Sector": "",
+        "Industry": "Software",
+        "Current Price": pd.NA,
+        "Market Cap": pd.NA,
+        "PE Ratio": pd.NA,
+        "Dividend Yield": pd.NA,
+    }
+    yf = {
+        "Ticker": "AAA",
+        "Name": "Acme",
+        "Sector": "Tech",
+        "Industry": "Software",
+        "Current Price": 1.0,
+        "Market Cap": 2.0,
+        "PE Ratio": 10.0,
+        "Dividend Yield": 0.1,
+    }
+    monkeypatch.setattr(uf, "_from_openbb", lambda t: openbb)
+    monkeypatch.setattr(uf, "fetch_basic_stock_data", lambda t: yf)
+    monkeypatch.setattr(uf, "resolve_term", lambda x: x)
+    result = uf.fetch_company_data("AAA")
+    assert result["Sector"] == "Tech"
+    assert result["Current Price"] == 1.0
+
+
+def test_yf_fallback(monkeypatch):
+    data = {"Ticker": "AAA"}
+    monkeypatch.setattr(uf, "_from_openbb", lambda t: None)
+    monkeypatch.setattr(uf, "fetch_basic_stock_data", lambda t: data)
+    monkeypatch.setattr(uf, "resolve_term", lambda x: x)
+    assert uf.fetch_company_data("AAA") == data
+
+
+def test_all_fail(monkeypatch):
+    monkeypatch.setattr(uf, "_from_openbb", lambda t: None)
+    monkeypatch.setattr(uf, "fetch_basic_stock_data", lambda t: (_ for _ in ()).throw(Exception("bad")))
+    monkeypatch.setattr(uf, "resolve_term", lambda x: x)
+    assert uf.fetch_company_data("AAA") is None
+
+
+def test_no_openbb(monkeypatch):
+    data = {"Ticker": "AAA"}
+    def boom(t):
+        raise AssertionError("should not call openbb")
+    monkeypatch.setattr(uf, "_from_openbb", boom)
+    monkeypatch.setattr(uf, "fetch_basic_stock_data", lambda t: data)
+    monkeypatch.setattr(uf, "resolve_term", lambda x: x)
+    assert uf.fetch_company_data("AAA", use_openbb=False) == data


### PR DESCRIPTION
## Summary
- auto-create collections before inserting with `create_collection_if_missing`
- log and handle missing fields in `unified_fetcher`
- expose new CLI commands to view Directus data
- allow `--no-openbb` flag to disable OpenBB fetching
- document Directus integration
- add tests for `unified_fetcher` and collection creation

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684277a6e28483279e762f9fab768e70