### PR TITLE
Add portfolio summary command

### DIFF
--- a/docs/scripts_overview.md
+++ b/docs/scripts_overview.md
@@ -26,10 +26,11 @@ The primary entry point. Running without arguments launches an interactive menu.
 4. Directus Tools      -> Directus helpers
 5. Settings            -> edit configuration
 6. Utilities           -> test runner and profiler
-7. View Portfolio      -> fetch portfolio from Directus
-8. View Profiles       -> show company profiles from Directus
-9. Exit                -> quit
+7. Exit                -> quit
 ```
+
+Additional subcommands are available without entering the menu:
+`summary`, `view-portfolio` and `view-profiles`.
 
 **Flow chart**
 

--- a/modules/analytics/__init__.py
+++ b/modules/analytics/__init__.py
@@ -25,6 +25,7 @@ __all__ = [
     "portfolio_summary",
     "sector_counts",
     "correlation_matrix",
+    "missing_field_counts",
     "moving_average",
     "percentage_change",
 ]
@@ -93,5 +94,31 @@ def correlation_matrix(df: pd.DataFrame) -> pd.DataFrame:
     if len(numeric_cols) < 2:
         return pd.DataFrame()
     return df[numeric_cols].corr()
+
+
+def missing_field_counts(df: pd.DataFrame) -> pd.DataFrame:
+    """Return count of missing values per column.
+
+    Parameters
+    ----------
+    df:
+        DataFrame to analyze.
+
+    Returns
+    -------
+    pd.DataFrame
+        Two-column DataFrame ``["Field", "Missing"]`` sorted by count.
+        An empty DataFrame is returned if ``df`` is empty or has no
+        missing values.
+    """
+    if df is None or df.empty:
+        return pd.DataFrame()
+    counts = df.isna().sum()
+    counts = counts[counts > 0]
+    if counts.empty:
+        return pd.DataFrame()
+    result = counts.sort_values(ascending=False).reset_index()
+    result.columns = ["Field", "Missing"]
+    return result
 
 

--- a/scripts/main.py
+++ b/scripts/main.py
@@ -54,7 +54,12 @@ setup_logging("logs/fundalyze.log")
 
 # Ensure environment variables from config/.env are loaded before other modules
 from modules.config_utils import load_settings  # noqa: E402
-from modules.interface import print_invalid_choice, print_header, print_menu
+from modules.interface import (
+    print_invalid_choice,
+    print_header,
+    print_menu,
+    print_table,
+)
 
 from modules.management.portfolio_manager.portfolio_manager import (
     main as run_portfolio_manager,
@@ -244,6 +249,32 @@ def view_directus_profiles() -> None:
     print_table(df)
 
 
+def portfolio_summary_cli() -> None:
+    """Display portfolio summary statistics and missing-field counts."""
+    from modules.management.portfolio_manager.portfolio_manager import load_portfolio
+    from modules.analytics import portfolio_summary, sector_counts, missing_field_counts
+
+    df = load_portfolio()
+    if df.empty:
+        print("Portfolio is empty.\n")
+        return
+
+    print_header("\U0001F4CA Portfolio Summary")
+    summary = portfolio_summary(df)
+    if not summary.empty:
+        print_table(summary, showindex=True)
+
+    counts = sector_counts(df)
+    if not counts.empty:
+        print("\nSectors:")
+        print_table(counts)
+
+    missing = missing_field_counts(df)
+    if not missing.empty:
+        print("\nMissing Fields:")
+        print_table(missing)
+
+
 def run_utilities_menu() -> None:
     """Sub-menu exposing extra helper utilities."""
     while True:
@@ -290,6 +321,7 @@ COMMAND_MAP: dict[str, Callable[[], None]] = {
     "profile": run_profile_cli,
     "view-portfolio": view_directus_portfolio,
     "view-profiles": view_directus_profiles,
+    "summary": portfolio_summary_cli,
 }
 
 COMMAND_HELP = {
@@ -306,6 +338,7 @@ COMMAND_HELP = {
     "profile": "Run performance profiler",
     "view-portfolio": "View portfolio from Directus",
     "view-profiles": "View company profiles from Directus",
+    "summary": "Display portfolio summary statistics",
 }
 
 

--- a/tests/test_analysis.py
+++ b/tests/test_analysis.py
@@ -2,7 +2,12 @@
 import pandas as pd
 from analytics import portfolio_summary, sector_counts
 import pytest
-from analytics import correlation_matrix, moving_average, percentage_change
+from analytics import (
+    correlation_matrix,
+    moving_average,
+    percentage_change,
+    missing_field_counts,
+)
 
 
 def test_portfolio_summary_numeric_columns():
@@ -69,3 +74,18 @@ def test_percentage_change_empty():
     empty = pd.Series(dtype=float)
     result = percentage_change(empty)
     assert result.empty
+
+
+def test_missing_field_counts_basic():
+    df = pd.DataFrame({
+        "A": [1, None, 2],
+        "B": [None, None, 3],
+    })
+    result = missing_field_counts(df)
+    assert result.iloc[0].tolist() == ["B", 2]
+    assert result.iloc[1].tolist() == ["A", 1]
+
+
+def test_missing_field_counts_no_missing():
+    df = pd.DataFrame({"A": [1, 2]})
+    assert missing_field_counts(df).empty

--- a/tests/test_main_summary.py
+++ b/tests/test_main_summary.py
@@ -1,0 +1,52 @@
+import os
+import sys
+import types
+import pandas as pd
+import importlib.util
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+# Patch missing modules expected by scripts.main
+sys.modules.setdefault(
+    "modules.generate_report.metadata_checker",
+    types.ModuleType("metadata_checker"),
+)
+sys.modules["modules.generate_report.metadata_checker"].run_for_tickers = lambda *a, **k: None
+sys.modules.setdefault(
+    "modules.generate_report.fallback_data",
+    types.ModuleType("fallback_data"),
+)
+sys.modules["modules.generate_report.fallback_data"].run_fallback_data = lambda *a, **k: None
+sys.modules.setdefault(
+    "modules.generate_report.excel_dashboard",
+    types.ModuleType("excel_dashboard"),
+)
+sys.modules["modules.generate_report.excel_dashboard"].create_and_open_dashboard = lambda *a, **k: None
+
+import modules.management.portfolio_manager.portfolio_manager as pm
+pm.PORTFOLIO_FILE = "dummy"
+
+spec = importlib.util.spec_from_file_location(
+    "main", os.path.join(os.path.dirname(__file__), "..", "scripts", "main.py")
+)
+main = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(main)
+
+
+def test_portfolio_summary_cli_empty(monkeypatch, capsys):
+    monkeypatch.setattr(pm, "load_portfolio", lambda: pd.DataFrame())
+    main.portfolio_summary_cli()
+    out = capsys.readouterr().out
+    assert "Portfolio is empty" in out
+
+
+def test_portfolio_summary_cli_missing(monkeypatch, capsys):
+    df = pd.DataFrame({
+        "Ticker": ["A", "B"],
+        "Current Price": [1.0, 2.0],
+        "Sector": ["Tech", None],
+    })
+    monkeypatch.setattr(pm, "load_portfolio", lambda: df)
+    main.portfolio_summary_cli()
+    out = capsys.readouterr().out
+    assert "Missing Fields:" in out


### PR DESCRIPTION
## Summary
- extend analytics with `missing_field_counts`
- expose new `summary` command in CLI
- document extra CLI subcommands
- test new analytics helper and summary CLI

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68427b7d858083279386330792a199a9