### PR TITLE
Cleanup docs and wizard

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ FMP_API_KEY=your-fmp-key
 The token is used by `modules.utils.get_openbb()` to authenticate with the OpenBB Hub
 whenever data is requested. See [docs/configuration.md](docs/configuration.md) for all options.
 
-## Quickstart
+## Quick Start
 Run the interactive menu:
 ```bash
 python scripts/main.py
@@ -76,6 +76,13 @@ The returned dictionary contains normalized company data.
 - `scripts/` – CLI entry points
 - `tests/` – pytest suite
 - `docs/` – extended documentation
+
+## Contributor Onboarding
+1. Fork the repository and clone your fork.
+2. Run `./bootstrap_env.sh` (or `.ps1` on Windows) to create `.venv` and install dependencies.
+3. Copy `config/.env` from the example and add your tokens.
+4. Execute `pytest -q` to ensure everything works before making changes.
+See [CONTRIBUTING.md](CONTRIBUTING.md) for more details.
 
 
 ## Resources

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -2,6 +2,10 @@
 
 This document summarizes the key modules and entry points in **Fundalyze**. Use it as a quick reference when navigating or extending the project.
 
+
+## Quick Start
+Run `python scripts/main.py` to open the interactive menu. Use the `portfolio` subcommand to manage your holdings directly from the command line.
+
 ```mermaid
 flowchart TD
     subgraph CLI
@@ -30,9 +34,9 @@ flowchart TD
 
 
 ### `modules.management`
-Tools for maintaining local data files:
-- `portfolio_manager` – CLI for creating and editing `portfolio.xlsx`.
-- `group_analysis` – manage related tickers in `groups.xlsx`.
+CLI helpers built around Directus collections:
+- `portfolio_manager` – manage your portfolio stored in Directus.
+- `group_analysis` – organize related tickers into groups.
 - `note_manager` – simple Markdown note system supporting `[[wikilinks]]`.
 
 For a walkthrough of each CLI and a diagram of the management package layout see
@@ -90,3 +94,9 @@ The `scripts/` directory contains small wrappers that import the modules above a
 
 
 Running `python scripts/main.py` without arguments opens the interactive menu; see the README for command examples.
+
+## Contributor Onboarding
+1. Fork the repository and clone your fork.
+2. Execute `./bootstrap_env.sh` to set up the virtual environment.
+3. Add API tokens to `config/.env` then run `pytest -q`.
+You're now ready to start hacking on Fundalyze!

--- a/modules/management/settings_manager/wizards/openbb_key.py
+++ b/modules/management/settings_manager/wizards/openbb_key.py
@@ -7,7 +7,12 @@ LABEL = "OpenBB API Token"
 
 def run_wizard() -> None:
     print("\n=== OpenBB API Token Setup ===")
-    print("Obtain a free API token at https://docs.openbb.co/platform/getting_started/api_requests\n")
+    print(
+        "More information about API requests: "
+        "https://docs.openbb.co/platform/getting_started/api_requests"
+    )
+    print("First login or register: https://my.openbb.co/login")
+    print("Obtain an API code here: https://my.openbb.co/app/platform/pat\n")
     token = input("Enter OpenBB API token: ").strip()
     if not token:
         print("No token provided.\n")


### PR DESCRIPTION
## Summary
- update OpenBB token instructions in the setup wizard
- add quick start and contributor guides to documentation
- clarify Directus usage in module overview

## Testing
- `pytest -q`
- `python scripts/main.py summary`

------
https://chatgpt.com/codex/tasks/task_e_684287661ff08327b22664f249a60e35