### PR TITLE
Cleanup docs, remove stale Excel references

### DIFF
--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -52,7 +52,7 @@ NAME
 
 DESCRIPTION
     Dependencies:
-        pip install yfinance pandas openpyxl
+        pip install yfinance pandas
     
     Usage:
         python portfolio_manager.py
@@ -61,8 +61,7 @@ DESCRIPTION
         A simple CLI tool to manage a stock portfolio. You can:
         - Add tickers (automatically fetch key data via yfinance; if fetch fails, confirm/adjust ticker or enter data manually).
         - Remove tickers.
-        - View current portfolio.
-        - Data is persisted in an Excel file ("portfolio.xlsx") in the same directory.
+        - View current portfolio stored in Directus.
 
 FUNCTIONS
     add_tickers(portfolio: pandas.core.frame.DataFrame) -> pandas.core.frame.DataFrame
@@ -78,10 +77,9 @@ FUNCTIONS
     fetch_from_yfinance(ticker: str) -> dict
         Wrapper around :func:`modules.data.fetching.fetch_basic_stock_data`.
     
-    load_portfolio(filepath: str) -> pandas.core.frame.DataFrame
-        Load the portfolio either from Directus (if configured) or from a local
-        Excel file. If loading fails, an empty DataFrame with the expected columns
-        is returned.
+    load_portfolio() -> pandas.core.frame.DataFrame
+        Load the portfolio from the configured Directus collection. If loading
+        fails, an empty DataFrame with the expected columns is returned.
     
     main()
     
@@ -92,9 +90,8 @@ FUNCTIONS
     remove_ticker(portfolio: pandas.core.frame.DataFrame) -> pandas.core.frame.DataFrame
         Prompt the user for a ticker to remove from the portfolio.
     
-    save_portfolio(df: pandas.core.frame.DataFrame, filepath: str)
-        Save the portfolio either to Directus (if configured) or to a local Excel
-        file as fallback.
+    save_portfolio(df: pandas.core.frame.DataFrame)
+        Persist the portfolio to the Directus collection.
     
     ticker_exists(df: pandas.core.frame.DataFrame, tk: str) -> bool
         Return True if the ticker already exists in the portfolio.
@@ -109,8 +106,7 @@ DATA
     COLUMNS = ['Ticker', 'Name', 'Sector', 'Industry', 'Current Price', 'M...
     C_DIRECTUS_COLLECTION = 'portfolio'
     FROM_DIRECTUS = {'company_name': 'Name', 'current_price': 'Current Pri...
-    PORTFOLIO_FILE = 'portfolio.xlsx'
-    USE_DIRECTUS = False
+    DIRECTUS_PORTFOLIO_COLLECTION = 'portfolio'
 
 FILE
     /workspace/Fundalyze/modules/management/portfolio_manager/portfolio_manager.py

--- a/docs/end_to_end_tests.md
+++ b/docs/end_to_end_tests.md
@@ -9,16 +9,16 @@ This document outlines the automated end-to-end tests for Fundalyze.
    OpenBB API responses and verifies that `fetch_and_compile()` writes the
    expected CSV files and metadata in a temporary output folder.
 2. **Dashboard Creation** – Using the generated CSV files the test invokes
-   `create_dashboard()` which combines the data into an Excel workbook. The
-   workbook is inspected to ensure the basic sheets (e.g. `Profile`,
-   `PriceHistory`) exist.
+   `create_dashboard()` which assembles a summary JSON report. The file is
+   inspected to ensure the expected keys (e.g. `profile`, `history`) exist.
 
 ## Portfolio Manager Workflow
 
 1. **Interactive CLI** – The test drives the `portfolio_manager` CLI by
    supplying a sequence of user inputs. It adds a ticker and then exits.
-2. **Persistence** – After the CLI terminates, the portfolio Excel file in the
-   temporary directory is read and validated to contain the added ticker.
+2. **Persistence** – After the CLI terminates, the in-memory portfolio is
+   validated to contain the added ticker and that the Directus collection was
+   updated.
 
 These tests exercise the main user journeys without relying on network access
 and run automatically as part of the test suite.

--- a/docs/utils_overview.md
+++ b/docs/utils_overview.md
@@ -1,7 +1,7 @@
 # Utility Modules
 
 This page describes the small helper modules under `modules/utils`. They are
-used across the codebase for data loading, Excel formatting and simple
+used across the codebase for data loading, optional JSON helpers and simple
 calculations.
 
 ```text


### PR DESCRIPTION
## Summary
- purge old Excel info from docs
- clarify utility modules overview
- adjust end-to-end test notes

## Testing
- `pytest -q`
- `python scripts/main.py summary`

------
https://chatgpt.com/codex/tasks/task_e_68428b5538948327a8781790d70c3bc9