### PR TITLE
Add mapping diagnostic utilities

### DIFF
--- a/modules/data/__init__.py
+++ b/modules/data/__init__.py
@@ -26,6 +26,7 @@ from .directus_mapper import (
     interactive_prepare_records,
     refresh_field_map,
     ensure_field_mapping,
+    add_missing_mappings,
 )
 from .unified_fetcher import fetch_company_data, fetch_and_store
 
@@ -53,6 +54,7 @@ __all__ = [
     "interactive_prepare_records",
     "refresh_field_map",
     "ensure_field_mapping",
+    "add_missing_mappings",
     "fetch_company_data",
     "fetch_and_store",
 ]

--- a/modules/data/directus_client.py
+++ b/modules/data/directus_client.py
@@ -236,8 +236,16 @@ def insert_items(collection: str, items):
     create_collection_if_missing(collection, fields)
 
     payload = {"data": cleaned}
+    logger.info("Inserting into %s: %s", collection, payload)
     result = directus_request("POST", f"items/{collection}", json=payload)
-    return _extract_data(result)
+    data = _extract_data(result)
+    if not data:
+        logger.warning(
+            "Insertion returned no data for %s | status/content: %s",
+            collection,
+            result,
+        )
+    return data
 
 
 def create_field(collection: str, field: str, field_type: str = "string", **kwargs):

--- a/scripts/main.py
+++ b/scripts/main.py
@@ -298,6 +298,7 @@ COMMAND_MAP: dict[str, Callable[[], None]] = {
     "view-portfolio": view_directus_portfolio,
     "view-profiles": view_directus_profiles,
     "map-record": debug_mapped_record,
+    "diag": lambda: subprocess.run(["python", "scripts/mapping_diagnostic.py"]),
     "summary": portfolio_summary_cli,
 }
 
@@ -312,6 +313,7 @@ COMMAND_HELP = {
     "view-portfolio": "View portfolio from Directus",
     "view-profiles": "View company profiles from Directus",
     "map-record": "Fetch and display mapped portfolio record",
+    "diag": "Run mapping diagnostic script",
     "summary": "Display portfolio summary statistics",
 }
 

--- a/scripts/mapping_diagnostic.py
+++ b/scripts/mapping_diagnostic.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python3
+"""Field mapping diagnostic helper for Fundalyze."""
+from modules.management.portfolio_manager import portfolio_manager as pm
+from modules.management.group_analysis import group_analysis as ga
+from modules.data.directus_mapper import load_field_map, prepare_records, add_missing_mappings
+from modules.data.directus_client import insert_items, fetch_items
+
+COLLECTIONS = {
+    pm.C_DIRECTUS_COLLECTION: pm.COLUMNS,
+    ga.GROUPS_COLLECTION: ga.COLUMNS,
+}
+
+def show_mapping(collection: str, expected: list[str]) -> None:
+    mapping = load_field_map().get("collections", {}).get(collection, {}).get("fields", {})
+    print(f"\n[{collection}] expected keys -> mapped fields")
+    for key in expected:
+        entry = mapping.get(key)
+        target = entry.get("mapped_to") if entry else None
+        print(f"  {key} -> {target}")
+
+
+def test_insert(ticker: str = "MSFT") -> None:
+    from modules.management.portfolio_manager.portfolio_manager import fetch_from_unified, C_DIRECTUS_COLLECTION
+
+    record = fetch_from_unified(ticker)
+    if not record:
+        print("Fetch failed")
+        return
+    print("Original:", record)
+    add_missing_mappings(C_DIRECTUS_COLLECTION, [record])
+    prepared = prepare_records(C_DIRECTUS_COLLECTION, [record], verbose=True)[0]
+    print("Prepared:", prepared)
+    res = insert_items(C_DIRECTUS_COLLECTION, [prepared])
+    print("Insert result:", res)
+    if res:
+        fetched = fetch_items(C_DIRECTUS_COLLECTION, limit=1)
+        print("Fetched back:", fetched)
+
+
+if __name__ == "__main__":
+    for col, expected in COLLECTIONS.items():
+        show_mapping(col, expected)
+    print("\nRunning test insert with ticker MSFT...")
+    test_insert()


### PR DESCRIPTION
## Summary
- log Directus insertion payload and check response
- enhance directus mapper with verbose diagnostics and auto mapping helper
- extend Directus tools menu with mapping and insert tests
- expose new helper via `data` package and CLI command
- add mapping_diagnostic.py script

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68429951ea308327b125549561a3d4e1