### PR TITLE
Improve mapping diagnostics

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,8 @@ or other tools that may use it.
 `scripts/sync_directus_fields.py` syncs your Directus instance to `directus_field_map.json`.
 1. Ensure `DIRECTUS_API_URL` and `DIRECTUS_TOKEN` are set.
 2. Run `python scripts/sync_directus_fields.py` and follow the prompts.
+You can verify your mapping at any time with `python scripts/main.py test-mapping`
+or insert a sample record using `python scripts/main.py test-insert`.
 
 ## Folder Structure
 - `modules/` – source packages

--- a/docs/scripts_overview.md
+++ b/docs/scripts_overview.md
@@ -57,3 +57,8 @@ Loads configuration from `config/.env` and performs a `GET <DIRECTUS_URL>/server
 
 ## sync_directus_fields.py
 Compares collections and fields in your Directus instance against `directus_field_map.json`. New collections/fields are presented for confirmation and deleted entries can be removed. If any API request fails, the script aborts and your existing mapping file remains unchanged.
+
+## mapping_diagnostic.py
+Prints the expected -> mapped field names for key collections and can optionally
+insert a test record. Use the new CLI commands `test-mapping` and `test-insert`
+to invoke this functionality from `main.py`.

--- a/modules/data/directus_client.py
+++ b/modules/data/directus_client.py
@@ -70,6 +70,13 @@ def _make_request(method: str, url: str, **kwargs) -> Dict[str, Any] | None:
             **kwargs,
         )
         resp.raise_for_status()
+        logger.info(
+            "Directus response %s %s status=%s content=%.200s",
+            method,
+            url,
+            resp.status_code,
+            resp.text,
+        )
     except requests.exceptions.HTTPError as http_err:
         status = getattr(resp, "status_code", "?")
         body = getattr(resp, "text", "")
@@ -238,6 +245,7 @@ def insert_items(collection: str, items):
     payload = {"data": cleaned}
     logger.info("Inserting into %s: %s", collection, payload)
     result = directus_request("POST", f"items/{collection}", json=payload)
+    logger.info("Insert result raw: %s", result)
     data = _extract_data(result)
     if not data:
         logger.warning(

--- a/modules/data/directus_mapper.py
+++ b/modules/data/directus_mapper.py
@@ -106,6 +106,7 @@ def _map_row(
         logger.error(
             "Mapping produced empty record. original=%s map=%s", row, field_map
         )
+        logger.error("Dropped keys: %s", ", ".join(dropped))
         raise ValueError(
             "Mapped record is empty. Check field mapping configuration"
         )

--- a/scripts/main.py
+++ b/scripts/main.py
@@ -230,6 +230,20 @@ def debug_mapped_record() -> None:
     print("Mapped record:\n", mapped)
 
 
+def run_mapping_test() -> None:
+    """Display current field mapping for portfolio and groups."""
+    subprocess.run([sys.executable, os.path.join(SCRIPT_DIR, "mapping_diagnostic.py")])
+
+
+def run_insert_test() -> None:
+    """Insert a test record for ticker MSFT and show the result."""
+    subprocess.run([
+        sys.executable,
+        os.path.join(SCRIPT_DIR, "mapping_diagnostic.py"),
+        "--insert",
+    ])
+
+
 def portfolio_summary_cli() -> None:
     """Display portfolio summary statistics and missing-field counts."""
     from modules.management.portfolio_manager.portfolio_manager import load_portfolio
@@ -263,6 +277,8 @@ def run_utilities_menu() -> None:
         options = [
             "Run Test Suite",
             "Performance Profile",
+            "Test Mapping",
+            "Test Insert",
             "Return to Main Menu",
         ]
         print_menu(options)
@@ -273,6 +289,10 @@ def run_utilities_menu() -> None:
         elif choice == "2":
             run_profile_cli()
         elif choice == "3":
+            run_mapping_test()
+        elif choice == "4":
+            run_insert_test()
+        elif choice == "5":
             break
         else:
             invalid_choice()
@@ -299,6 +319,8 @@ COMMAND_MAP: dict[str, Callable[[], None]] = {
     "view-profiles": view_directus_profiles,
     "map-record": debug_mapped_record,
     "diag": lambda: subprocess.run(["python", "scripts/mapping_diagnostic.py"]),
+    "test-mapping": run_mapping_test,
+    "test-insert": run_insert_test,
     "summary": portfolio_summary_cli,
 }
 
@@ -314,6 +336,8 @@ COMMAND_HELP = {
     "view-profiles": "View company profiles from Directus",
     "map-record": "Fetch and display mapped portfolio record",
     "diag": "Run mapping diagnostic script",
+    "test-mapping": "Display current field mapping",
+    "test-insert": "Insert a test record into Directus",
     "summary": "Display portfolio summary statistics",
 }
 

--- a/scripts/mapping_diagnostic.py
+++ b/scripts/mapping_diagnostic.py
@@ -1,8 +1,13 @@
 #!/usr/bin/env python3
 """Field mapping diagnostic helper for Fundalyze."""
+import argparse
 from modules.management.portfolio_manager import portfolio_manager as pm
 from modules.management.group_analysis import group_analysis as ga
-from modules.data.directus_mapper import load_field_map, prepare_records, add_missing_mappings
+from modules.data.directus_mapper import (
+    load_field_map,
+    prepare_records,
+    add_missing_mappings,
+)
 from modules.data.directus_client import insert_items, fetch_items
 
 COLLECTIONS = {
@@ -37,8 +42,27 @@ def test_insert(ticker: str = "MSFT") -> None:
         print("Fetched back:", fetched)
 
 
-if __name__ == "__main__":
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Field mapping diagnostics")
+    parser.add_argument(
+        "--insert",
+        action="store_true",
+        help="Test inserting a record after displaying mapping",
+    )
+    parser.add_argument(
+        "--ticker",
+        default="MSFT",
+        help="Ticker symbol to use with --insert",
+    )
+    args = parser.parse_args()
+
     for col, expected in COLLECTIONS.items():
         show_mapping(col, expected)
-    print("\nRunning test insert with ticker MSFT...")
-    test_insert()
+
+    if args.insert:
+        print(f"\nRunning test insert with ticker {args.ticker}...")
+        test_insert(args.ticker)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- log Directus responses in `_make_request`
- expose raw insert result from `insert_items`
- warn about dropped keys when mapping empty
- add mapping diagnostic CLI options
- document `test-mapping` and `test-insert` commands

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68429ba9f97c832788f2dbf140376dd4