### PR TITLE
Update docs for new CLI mapping commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,10 @@ Debug how a ticker is mapped before insertion:
 ```bash
 python scripts/main.py map-record
 ```
+Run a full mapping diagnostic:
+```bash
+python scripts/main.py diag
+```
 
 Programmatic use:
 ```python
@@ -84,7 +88,8 @@ or other tools that may use it.
 `scripts/sync_directus_fields.py` syncs your Directus instance to `directus_field_map.json`.
 1. Ensure `DIRECTUS_API_URL` and `DIRECTUS_TOKEN` are set.
 2. Run `python scripts/sync_directus_fields.py` and follow the prompts.
-You can verify your mapping at any time with `python scripts/main.py test-mapping`
+You can verify your mapping at any time with `python scripts/main.py test-mapping`,
+run a detailed diagnostic with `python scripts/main.py diag`,
 or insert a sample record using `python scripts/main.py test-insert`.
 To automatically append any new fields in a dataset run
 `python scripts/main.py add-missing` and follow the prompts.

--- a/docs/scripts_overview.md
+++ b/docs/scripts_overview.md
@@ -59,9 +59,9 @@ Loads configuration from `config/.env` and performs a `GET <DIRECTUS_URL>/server
 Compares collections and fields in your Directus instance against `directus_field_map.json`. New collections/fields are presented for confirmation and deleted entries can be removed. If any API request fails, the script aborts and your existing mapping file remains unchanged.
 
 ## mapping_diagnostic.py
-Prints the expected -> mapped field names for key collections and can optionally
-insert a test record. Use the new CLI commands `test-mapping` and `test-insert`
-to invoke this functionality from `main.py`.
+Prints the expected → mapped field names for key collections and can optionally
+insert a test record. Run `python scripts/main.py diag` for a full diagnostic or
+use the `test-mapping` and `test-insert` subcommands directly from `main.py`.
 
 ## add_missing_mappings.py
 Appends any new keys found in a JSON dataset to `directus_field_map.json`.


### PR DESCRIPTION
## Summary
- mention `diag` command in README Quick Start
- expand mapping instructions to include `diag`
- clarify mapping_diagnostic usage in docs

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6842ab9149c483279a865b9553138008