### PR TITLE
Cleanup CLI invalid command handling

### DIFF
--- a/scripts/main.py
+++ b/scripts/main.py
@@ -443,6 +443,7 @@ def main() -> None:
     if action:
         action()
     else:
+        print(f"Unknown command: {cmd}\n")
         interactive_menu()
 
 


### PR DESCRIPTION
## Summary
- show message when a command isn't recognized before falling back to the main menu

## Testing
- `pytest -q`
- `python scripts/main.py --version`


------
https://chatgpt.com/codex/tasks/task_e_6842ade9fa14832781c9a0f60678fd66