### PR TITLE
Fix mapping_validator path import

### DIFF
--- a/scripts/mapping_validator.py
+++ b/scripts/mapping_validator.py
@@ -13,8 +13,15 @@ from __future__ import annotations
 import argparse
 import json
 import logging
+import os
+import sys
 from pathlib import Path
 from typing import Any, Dict, Iterable, List
+
+SCRIPT_DIR = os.path.dirname(__file__)
+REPO_ROOT = os.path.abspath(os.path.join(SCRIPT_DIR, os.pardir))
+if REPO_ROOT not in sys.path:
+    sys.path.insert(0, REPO_ROOT)
 
 from modules.data import directus_mapper as dm
 from modules.data.directus_client import insert_items, list_fields


### PR DESCRIPTION
## Summary
- fix mapping_validator import path by appending repo root

## Testing
- `pytest -q`
- `python scripts/mapping_validator.py portfolio test.json -v`

------
https://chatgpt.com/codex/tasks/task_e_6842b3eb53508327a25756fd98143d84