### PR TITLE
Add coverage for utils and client helpers

### DIFF
--- a/tests/test_data_utils_edge.py
+++ b/tests/test_data_utils_edge.py
@@ -1,9 +1,12 @@
 """Tests for data utility edge scenarios."""
+import json
 import pandas as pd
 from modules.utils.data_utils import (
     ensure_period_column,
     read_csv_if_exists,
     read_json_if_exists,
+    strip_timezones,
+    write_dataframe,
 )
 
 
@@ -51,3 +54,22 @@ def test_read_json_if_exists(tmp_path):
 def test_read_json_if_exists_missing(tmp_path):
     path = tmp_path / 'missing.json'
     assert read_json_if_exists(path) is None
+
+
+def test_strip_timezones():
+    idx = pd.date_range('2020-01-01', periods=2, tz='UTC')
+    df = pd.DataFrame({'A': pd.date_range('2020-01-01', periods=2, tz='US/Eastern')}, index=idx)
+    result = strip_timezones(df)
+    assert result.index.tz is None
+    assert result['A'].dt.tz is None
+
+
+def test_write_dataframe_csv_and_json(tmp_path):
+    df = pd.DataFrame({'A': [1]})
+    path = tmp_path / 'out.csv'
+    write_dataframe(df, path, write_csv=True, write_json=True)
+    assert path.is_file()
+    csv_read = pd.read_csv(path)
+    assert csv_read.equals(df)
+    json_data = json.loads(path.with_suffix('.json').read_text())
+    assert json_data[0]['A'] == 1

--- a/tests/test_directus_client_extra.py
+++ b/tests/test_directus_client_extra.py
@@ -1,0 +1,34 @@
+from requests import Response
+import modules.data.directus_client as dc
+
+
+def make_response(text, content_type="application/json"):
+    resp = Response()
+    resp.status_code = 200
+    resp._content = text.encode("utf-8")
+    resp.headers["content-type"] = content_type
+    return resp
+
+
+def test_parse_response_html():
+    resp = make_response("<html></html>", "text/html")
+    assert dc._parse_response(resp, "http://api") is None
+
+
+def test_parse_response_invalid_json():
+    resp = make_response("not json")
+    assert dc._parse_response(resp, "http://api") is None
+
+
+def test_parse_response_valid_json():
+    resp = make_response('{"a": 1}')
+    assert dc._parse_response(resp, "http://api") == {"a": 1}
+
+
+def test_clean_record_nan_inf():
+    record = {"a": 1.0, "b": float("nan"), "c": float("inf"), "d": float("-inf")}
+    cleaned = dc.clean_record(record)
+    assert cleaned["a"] == 1.0
+    assert cleaned["b"] is None
+    assert cleaned["c"] is None
+    assert cleaned["d"] is None

--- a/tests/test_openbb_utils.py
+++ b/tests/test_openbb_utils.py
@@ -1,0 +1,42 @@
+import importlib
+import sys
+from types import SimpleNamespace
+
+import modules.utils.openbb_utils as ou
+
+
+def setup_dummy(monkeypatch, login_func):
+    dummy = SimpleNamespace(account=SimpleNamespace(login=login_func))
+    monkeypatch.setitem(sys.modules, "openbb", SimpleNamespace(obb=dummy))
+    importlib.reload(ou)
+    return dummy
+
+
+def test_get_openbb_with_token(monkeypatch):
+    calls = []
+
+    def login(pat):
+        calls.append(pat)
+
+    dummy = setup_dummy(monkeypatch, login)
+    monkeypatch.setenv("OPENBB_TOKEN", "tok")
+    obb = ou.get_openbb()
+    assert obb is dummy
+    assert calls == ["tok"]
+    ou.get_openbb()
+    assert calls == ["tok"]
+
+
+def test_get_openbb_no_token(monkeypatch, capsys):
+    calls = []
+
+    def login(pat):
+        calls.append(pat)
+
+    dummy = setup_dummy(monkeypatch, login)
+    monkeypatch.delenv("OPENBB_TOKEN", raising=False)
+    obb = ou.get_openbb()
+    out = capsys.readouterr().out
+    assert "OPENBB_TOKEN environment variable not set" in out
+    assert calls == []
+    assert obb is dummy


### PR DESCRIPTION
## Summary
- add tests for strip_timezones and write_dataframe
- add tests for Directus client helper functions
- add tests for OpenBB login utility

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6842b7743bc4832788d3a2366712d667