### PR TITLE
Add extra tests for config and logging utils

### DIFF
--- a/tests/test_config_utils.py
+++ b/tests/test_config_utils.py
@@ -34,3 +34,23 @@ def test_env_roundtrip(tmp_path, monkeypatch):
     config_utils.save_env(env)
     loaded = config_utils.load_env()
     assert loaded == env
+
+
+def test_add_fmp_api_key_with_env(monkeypatch):
+    monkeypatch.setenv("FMP_API_KEY", "abc123")
+    url = "https://example.com/profile"
+    result = config_utils.add_fmp_api_key(url)
+    assert result == url + "?apikey=abc123"
+
+
+def test_add_fmp_api_key_with_query(monkeypatch):
+    monkeypatch.setenv("FMP_API_KEY", "key")
+    url = "https://example.com/profile?x=1"
+    result = config_utils.add_fmp_api_key(url)
+    assert result == url + "&apikey=key"
+
+
+def test_add_fmp_api_key_no_env(monkeypatch):
+    monkeypatch.delenv("FMP_API_KEY", raising=False)
+    url = "https://example.com/profile"
+    assert config_utils.add_fmp_api_key(url) == url

--- a/tests/test_logging_utils.py
+++ b/tests/test_logging_utils.py
@@ -1,0 +1,17 @@
+import logging
+from modules.logging_utils import setup_logging
+
+
+def test_setup_logging_creates_file_and_logs(tmp_path):
+    log_file = tmp_path / "test.log"
+    logging.getLogger().handlers.clear()
+    setup_logging(str(log_file))
+    assert log_file.is_file()
+    logging.getLogger().info("hello")
+    for h in logging.getLogger().handlers:
+        if hasattr(h, "flush"):
+            h.flush()
+    content = log_file.read_text()
+    assert "hello" in content
+    assert "INFO" in content
+    logging.getLogger().handlers.clear()


### PR DESCRIPTION
## Summary
- improve coverage around config helper for FMP API key
- add tests exercising logging setup utility

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6842ba20efa48327868e5c55fb875b35