### PR TITLE
Fix default mapping for Directus fields

### DIFF
--- a/directus_field_map_example.json
+++ b/directus_field_map_example.json
@@ -2,14 +2,14 @@
   "collections": {
     "portfolio": {
       "fields": {
-        "Ticker": {"type": "string", "mapped_to": "ticker"},
-        "Name": {"type": "string", "mapped_to": "name"},
+        "Ticker": {"type": "string", "mapped_to": "ticker_symbol"},
+        "Name": {"type": "string", "mapped_to": "company_name"},
         "Sector": {"type": "string", "mapped_to": "sector"},
         "Industry": {"type": "string", "mapped_to": "industry"},
-        "Current Price": {"type": "float", "mapped_to": "current_price"},
-        "Market Cap": {"type": "float", "mapped_to": "market_cap"},
-        "PE Ratio": {"type": "float", "mapped_to": "pe_ratio"},
-        "Dividend Yield": {"type": "float", "mapped_to": "dividend_yield"}
+        "Current Price": {"type": "decimal", "mapped_to": "current_price"},
+        "Market Cap": {"type": "decimal", "mapped_to": "market_cap"},
+        "PE Ratio": {"type": "decimal", "mapped_to": "pe_ratio"},
+        "Dividend Yield": {"type": "decimal", "mapped_to": "dividend_yield"}
       }
     }
   }


### PR DESCRIPTION
## Summary
- update `directus_field_map_example.json` so fetched columns map to Directus field names

## Testing
- `pytest -k directus_mapper -q`

------
https://chatgpt.com/codex/tasks/task_e_6842c1f2f57c8327b8af36b98e73ab15