### PR TITLE
Restore financial statement Directus integration

### DIFF
--- a/modules/data/__init__.py
+++ b/modules/data/__init__.py
@@ -29,6 +29,11 @@ from .directus_mapper import (
     add_missing_mappings,
 )
 from .unified_fetcher import fetch_company_data, fetch_and_store
+from .financials import (
+    fetch_statements,
+    store_statements,
+    fetch_and_store_statements,
+)
 
 __all__ = [
     "fetch_basic_stock_data",
@@ -57,4 +62,7 @@ __all__ = [
     "add_missing_mappings",
     "fetch_company_data",
     "fetch_and_store",
+    "fetch_statements",
+    "store_statements",
+    "fetch_and_store_statements",
 ]

--- a/modules/data/financials.py
+++ b/modules/data/financials.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+"""Fetch financial statements and insert them into Directus."""
+
+import os
+import logging
+from typing import Iterable, Dict
+
+import pandas as pd
+
+from modules.utils import get_openbb, parse_number
+from .directus_client import insert_items
+from .directus_mapper import prepare_records
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_STATEMENTS = ("income", "balance", "cash")
+
+COLLECTION_MAP = {
+    "income": "income_statement",
+    "balance": "balance_sheet",
+    "cash": "cash_flow",
+}
+
+
+def _fetch_statement(obb, ticker: str, stmt: str, period: str) -> pd.DataFrame:
+    """Return statement DataFrame from OpenBB or empty DataFrame."""
+    try:
+        fn = getattr(obb.equity.fundamental, stmt)
+        df = fn(symbol=ticker, period=period).to_df()
+        if isinstance(df, pd.DataFrame):
+            # Normalize numeric values
+            return df.applymap(parse_number)
+    except Exception as exc:  # pragma: no cover - network errors
+        logger.warning("%s %s fetch failed for %s: %s", stmt, period, ticker, exc)
+    return pd.DataFrame()
+
+
+def fetch_statements(ticker: str, statements: Iterable[str] | None = None) -> Dict[str, Dict[str, pd.DataFrame]]:
+    """Return financial statements for ``ticker`` grouped by statement and period."""
+    if statements is None:
+        statements = DEFAULT_STATEMENTS
+    obb = get_openbb()
+    data: Dict[str, Dict[str, pd.DataFrame]] = {}
+    for stmt in statements:
+        data[stmt] = {
+            "annual": _fetch_statement(obb, ticker, stmt, "annual"),
+            "quarter": _fetch_statement(obb, ticker, stmt, "quarter"),
+        }
+    return data
+
+
+def _insert_dataframe(df: pd.DataFrame, collection: str) -> None:
+    """Prepare and insert ``df`` rows into Directus collection."""
+    if df.empty:
+        return
+    records = prepare_records(collection, df.reset_index().to_dict(orient="records"))
+    try:
+        insert_items(collection, records)
+    except Exception as exc:  # pragma: no cover - network errors
+        logger.error("Directus insertion failed for %s: %s", collection, exc)
+
+
+def store_statements(data: Dict[str, Dict[str, pd.DataFrame]]) -> None:
+    """Insert fetched statements into Directus using environment collection names."""
+    for stmt, periods in data.items():
+        base = COLLECTION_MAP.get(stmt, stmt)
+        collection = os.getenv(f"DIRECTUS_{base.upper()}_COLLECTION", base)
+        for period, df in periods.items():
+            if not df.empty:
+                df = df.copy()
+                df.insert(0, "period", df.index)
+                _insert_dataframe(df, collection)
+
+
+def fetch_and_store_statements(
+    ticker: str, *, statements: Iterable[str] | None = None
+) -> Dict[str, Dict[str, pd.DataFrame]]:
+    """Fetch financial statements for ``ticker`` and store them in Directus."""
+    data = fetch_statements(ticker, statements)
+    store_statements(data)
+    return data

--- a/tests/test_financials.py
+++ b/tests/test_financials.py
@@ -1,0 +1,53 @@
+import pandas as pd
+import modules.data.financials as fin
+
+class Dummy:
+    def __init__(self, df):
+        self._df = df
+    def to_df(self):
+        return self._df
+
+class DummyFundamental:
+    def __init__(self, df):
+        self.income = lambda symbol, period: Dummy(df)
+        self.balance = lambda symbol, period: Dummy(df)
+        self.cash = lambda symbol, period: Dummy(df)
+
+class DummyEquity:
+    def __init__(self, df):
+        self.fundamental = DummyFundamental(df)
+
+class DummyOBB:
+    def __init__(self, df):
+        self.equity = DummyEquity(df)
+
+
+def test_fetch_statements(monkeypatch):
+    df = pd.DataFrame({"A": ["1B"]}, index=["2024"])
+    obb = DummyOBB(df)
+    monkeypatch.setattr(fin, "get_openbb", lambda: obb)
+    result = fin.fetch_statements("AAA")
+    assert result["income"]["annual"].iloc[0, 0] == 1_000_000_000
+
+
+def test_store_statements(monkeypatch):
+    captured = {}
+    monkeypatch.setattr(fin, "prepare_records", lambda c, r: r)
+    monkeypatch.setattr(fin, "insert_items", lambda col, rec: captured.setdefault(col, []).extend(rec))
+    data = {"income": {"annual": pd.DataFrame({"A": [1]}, index=["2024"]), "quarter": pd.DataFrame()},
+            "balance": {"annual": pd.DataFrame(), "quarter": pd.DataFrame()}}
+    fin.store_statements(data)
+    assert "income_statement" in captured
+    assert captured["income_statement"][0]["period"] == "2024"
+
+
+def test_fetch_and_store_statements(monkeypatch):
+    df = pd.DataFrame({"A": [1]}, index=["2024"])
+    obb = DummyOBB(df)
+    monkeypatch.setattr(fin, "get_openbb", lambda: obb)
+    monkeypatch.setattr(fin, "prepare_records", lambda c, r: r)
+    inserted = {}
+    monkeypatch.setattr(fin, "insert_items", lambda c, r: inserted.setdefault(c, []).extend(r))
+    fin.fetch_and_store_statements("ZZZ", statements=["income"])
+    assert inserted["income_statement"][0]["A"] == 1
+


### PR DESCRIPTION
## Summary
- reintroduce functionality to fetch income statement, balance sheet and cash flow using OpenBB
- insert fetched statements into Directus collections
- expose new helpers via `modules.data`
- cover new module with unit tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6842df700b5083278ef7f822975871b4