### PR TITLE
Fix directus single insert payload

### DIFF
--- a/modules/data/directus_client.py
+++ b/modules/data/directus_client.py
@@ -234,6 +234,10 @@ def insert_items(collection: str, items):
         logger.warning("No records to insert.")
         return []
 
+    # Allow single dictionaries in addition to iterables
+    if isinstance(items, dict):
+        items = [items]
+
     cleaned = []
     for item in items:
         if isinstance(item, dict):
@@ -244,7 +248,10 @@ def insert_items(collection: str, items):
     fields = cleaned[0].keys() if isinstance(cleaned[0], dict) else None
     create_collection_if_missing(collection, fields)
 
-    payload = {"data": cleaned}
+    if len(cleaned) == 1:
+        payload = {"data": cleaned[0]}
+    else:
+        payload = {"data": cleaned}
     logger.info("Inserting into %s: %s", collection, payload)
     result = directus_request("POST", f"items/{collection}", json=payload)
     logger.info("Insert result raw: %s", result)

--- a/modules/utils/__init__.py
+++ b/modules/utils/__init__.py
@@ -13,6 +13,7 @@ from .data_utils import (
     read_csv_if_exists,
     read_json_if_exists,
     parse_number,
+    parse_human_number,
 )
 from .math_utils import moving_average, percentage_change
 from .progress_utils import progress_iter
@@ -24,6 +25,7 @@ __all__ = [
     "read_csv_if_exists",
     "read_json_if_exists",
     "parse_number",
+    "parse_human_number",
     "moving_average",
     "percentage_change",
     "progress_iter",

--- a/modules/utils/data_utils.py
+++ b/modules/utils/data_utils.py
@@ -107,3 +107,8 @@ def parse_number(val: Any) -> Any:
         except ValueError:
             return val
     return val
+
+
+def parse_human_number(val: Any) -> Any:
+    """Return numeric value parsed from ``val`` if possible."""
+    return parse_number(val)

--- a/tests/test_directus_client.py
+++ b/tests/test_directus_client.py
@@ -87,14 +87,14 @@ def test_insert_items(monkeypatch):
         called["method"] = method
         called["path"] = path
         called["payload"] = kw.get("json")
-        return {"data": [1]}
+        return {"data": 1}
 
     monkeypatch.setattr(dc, "directus_request", fake_request)
     res = dc.insert_items("col", [1])
     assert called["method"] == "POST"
     assert called["path"] == "items/col"
-    assert called["payload"] == {"data": [1]}
-    assert res == [1]
+    assert called["payload"] == {"data": 1}
+    assert res == 1
 
 
 def test_list_collections(monkeypatch):
@@ -157,7 +157,7 @@ def test_insert_items_auto_creates(monkeypatch):
     monkeypatch.setattr(dc, "DIRECTUS_URL", "http://api")
     called = {}
     monkeypatch.setattr(dc, "create_collection_if_missing", lambda c, f=None: called.setdefault("called", True))
-    monkeypatch.setattr(dc, "directus_request", lambda *a, **k: {"data": [1]})
+    monkeypatch.setattr(dc, "directus_request", lambda *a, **k: {"data": {"id": 1}})
     res = dc.insert_items("col", [{"x": 1}])
     assert "called" in called
-    assert res == [1]
+    assert res == {"id": 1}

--- a/tests/test_parse_number.py
+++ b/tests/test_parse_number.py
@@ -1,5 +1,5 @@
 import pandas as pd
-from modules.utils import parse_number
+from modules.utils import parse_number, parse_human_number
 
 
 def test_parse_number_numeric():
@@ -17,3 +17,7 @@ def test_parse_number_invalid():
     assert parse_number("N/A") == "N/A"
     assert parse_number(None) is None
     assert parse_number(pd.NA) is pd.NA
+
+
+def test_parse_human_number_alias():
+    assert parse_human_number("1M") == 1_000_000


### PR DESCRIPTION
## Summary
- handle single item payloads in directus client
- expose new `parse_human_number` helper
- update tests for new payload behaviour

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6842e2437dfc832784233a4802a35256