### PR TITLE
Implement Directus schema sync utilities

### DIFF
--- a/config/schema_definitions.csv
+++ b/config/schema_definitions.csv
@@ -1,0 +1,4 @@
+table_name,field_name,type,precision,scale,required,default
+balance_sheet,total_assets,decimal,1000,10,TRUE,
+cash_flow,free_cash_flow,decimal,1000,10,FALSE,0
+portfolio,current_price,decimal,10,5,TRUE,

--- a/main.py
+++ b/main.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+"""Entry point for schema synchronization utilities."""
+
+import argparse
+
+from modules.logging_utils import setup_logging
+from modules.api import DirectusClient
+from modules.schema import export_schema, sync_schema
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Directus schema utilities")
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    exp = sub.add_parser("export", help="Export Directus schema to CSV")
+    exp.add_argument(
+        "--output",
+        default="config/schema_definitions_export.csv",
+        help="Destination CSV file",
+    )
+
+    sync = sub.add_parser("sync", help="Sync CSV schema to Directus")
+    sync.add_argument(
+        "--csv",
+        default="config/schema_definitions.csv",
+        help="CSV file with schema definitions",
+    )
+    sync.add_argument(
+        "--delete-extra",
+        action="store_true",
+        help="Delete fields not defined in CSV",
+    )
+
+    return parser.parse_args()
+
+
+def main() -> None:
+    setup_logging("logs/schema_sync.log")
+    args = parse_args()
+    client = DirectusClient()
+    if args.command == "export":
+        export_schema(client, args.output)
+    elif args.command == "sync":
+        sync_schema(args.csv, client, remove_extra=args.delete_extra)
+
+
+if __name__ == "__main__":
+    main()

--- a/modules/api/__init__.py
+++ b/modules/api/__init__.py
@@ -1,0 +1,5 @@
+"""API client wrappers used by Fundalyze."""
+
+from .directus_client import DirectusClient
+
+__all__ = ["DirectusClient"]

--- a/modules/api/directus_client.py
+++ b/modules/api/directus_client.py
@@ -1,0 +1,83 @@
+from __future__ import annotations
+
+"""Thin wrapper around the Directus REST API."""
+
+import logging
+import os
+from typing import Any, Dict, Optional
+
+import requests
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_TIMEOUT = 30
+
+
+class DirectusClient:
+    """Simple Directus API client.
+
+    Parameters
+    ----------
+    base_url:
+        Directus base URL. Falls back to ``DIRECTUS_URL`` env var.
+    token:
+        API token. Falls back to ``DIRECTUS_API_TOKEN`` or ``DIRECTUS_TOKEN``.
+    """
+
+    def __init__(self, base_url: Optional[str] = None, token: Optional[str] = None) -> None:
+        self.base_url = base_url or os.getenv("DIRECTUS_URL", "")
+        self.token = token or os.getenv("DIRECTUS_API_TOKEN") or os.getenv("DIRECTUS_TOKEN")
+        if not self.base_url:
+            raise RuntimeError("DIRECTUS_URL not configured")
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+    def _headers(self) -> Dict[str, str]:
+        headers = {"Accept": "application/json"}
+        if self.token:
+            headers["Authorization"] = f"Bearer {self.token}"
+        return headers
+
+    def _request(self, method: str, path: str, **kwargs) -> Dict[str, Any] | None:
+        url = f"{self.base_url.rstrip('/')}/{path.lstrip('/')}"
+        try:
+            logger.debug("Directus request %s %s", method, url)
+            resp = requests.request(
+                method,
+                url,
+                headers=self._headers(),
+                timeout=DEFAULT_TIMEOUT,
+                **kwargs,
+            )
+            resp.raise_for_status()
+        except requests.RequestException as exc:
+            logger.error("Directus request failed: %s", exc)
+            return None
+        try:
+            return resp.json()
+        except ValueError:
+            logger.error("Invalid JSON response from %s: %s", url, resp.text)
+            return None
+
+    # ------------------------------------------------------------------
+    # Schema helpers
+    # ------------------------------------------------------------------
+    def list_collections(self) -> list[str]:
+        data = self._request("GET", "collections") or {}
+        return [c.get("collection") for c in data.get("data", [])]
+
+    def list_fields(self, collection: str) -> list[Dict[str, Any]]:
+        data = self._request("GET", f"fields/{collection}") or {}
+        return data.get("data", [])
+
+    def create_field(self, collection: str, field: str, definition: Dict[str, Any]) -> Any:
+        payload = {"field": field}
+        payload.update(definition)
+        return self._request("POST", f"fields/{collection}", json=payload)
+
+    def update_field(self, collection: str, field: str, definition: Dict[str, Any]) -> Any:
+        return self._request("PATCH", f"fields/{collection}/{field}", json=definition)
+
+    def delete_field(self, collection: str, field: str) -> Any:
+        return self._request("DELETE", f"fields/{collection}/{field}")

--- a/modules/schema/__init__.py
+++ b/modules/schema/__init__.py
@@ -1,0 +1,7 @@
+"""Helpers for managing Directus schema definitions."""
+
+from .schema_loader import load_schema
+from .schema_exporter import export_schema, fetch_schema
+from .schema_syncer import sync_schema
+
+__all__ = ["load_schema", "export_schema", "fetch_schema", "sync_schema"]

--- a/modules/schema/schema_exporter.py
+++ b/modules/schema/schema_exporter.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+"""Export and fetch schema definitions from Directus."""
+
+import csv
+import logging
+from pathlib import Path
+from typing import Any, Dict
+
+from modules.api.directus_client import DirectusClient
+
+logger = logging.getLogger(__name__)
+
+CSV_COLUMNS = [
+    "table_name",
+    "field_name",
+    "type",
+    "precision",
+    "scale",
+    "required",
+    "default",
+]
+
+
+def fetch_schema(client: DirectusClient) -> Dict[str, Dict[str, Dict[str, Any]]]:
+    """Return schema information from Directus as nested dictionaries."""
+    schema: Dict[str, Dict[str, Dict[str, Any]]] = {}
+    for collection in client.list_collections():
+        fields = client.list_fields(collection)
+        for f in fields:
+            schema.setdefault(collection, {})[f.get("field")] = f
+    return schema
+
+
+def export_schema(client: DirectusClient, output: str | Path) -> None:
+    """Write current Directus schema to ``output`` CSV file."""
+    csv_path = Path(output)
+    rows = []
+    for collection in client.list_collections():
+        fields = client.list_fields(collection)
+        for f in fields:
+            rows.append(
+                {
+                    "table_name": collection,
+                    "field_name": f.get("field"),
+                    "type": f.get("type"),
+                    "precision": f.get("precision"),
+                    "scale": f.get("scale"),
+                    "required": not f.get("schema", {}).get("is_nullable", True),
+                    "default": f.get("default_value"),
+                }
+            )
+    csv_path.parent.mkdir(parents=True, exist_ok=True)
+    with csv_path.open("w", newline="", encoding="utf-8") as fh:
+        writer = csv.DictWriter(fh, fieldnames=CSV_COLUMNS)
+        writer.writeheader()
+        writer.writerows(rows)
+    logger.info("Schema definitions exported to %s", csv_path)

--- a/modules/schema/schema_loader.py
+++ b/modules/schema/schema_loader.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+"""Load schema definitions from CSV files."""
+
+import csv
+import logging
+from pathlib import Path
+from typing import Any, Dict
+
+logger = logging.getLogger(__name__)
+
+CSV_COLUMNS = [
+    "table_name",
+    "field_name",
+    "type",
+    "precision",
+    "scale",
+    "required",
+    "default",
+]
+
+VALID_TYPES = {"integer", "decimal", "string", "boolean", "datetime", "date", "text"}
+
+
+def load_schema(path: str | Path = Path("config/schema_definitions.csv")) -> Dict[str, Dict[str, Dict[str, Any]]]:
+    """Return schema definitions loaded from ``path``.
+
+    The CSV must contain the columns defined in :data:`CSV_COLUMNS`.
+    Duplicate ``table_name``/``field_name`` pairs or invalid types raise
+    ``ValueError``.
+    """
+
+    csv_path = Path(path)
+    if not csv_path.is_file():
+        raise FileNotFoundError(csv_path)
+
+    schema: Dict[str, Dict[str, Dict[str, Any]]] = {}
+    with csv_path.open(newline="", encoding="utf-8") as fh:
+        reader = csv.DictReader(fh)
+        missing = [c for c in CSV_COLUMNS if c not in (reader.fieldnames or [])]
+        if missing:
+            raise ValueError(f"Missing columns: {', '.join(missing)}")
+
+        for row in reader:
+            table = row["table_name"].strip()
+            field = row["field_name"].strip()
+            ftype = row["type"].strip().lower()
+            if ftype not in VALID_TYPES:
+                raise ValueError(f"Invalid type '{ftype}' for {table}.{field}")
+            if table not in schema:
+                schema[table] = {}
+            if field in schema[table]:
+                raise ValueError(f"Duplicate field {table}.{field}")
+            schema[table][field] = {
+                "type": ftype,
+                "precision": row.get("precision", "").strip() or None,
+                "scale": row.get("scale", "").strip() or None,
+                "required": row.get("required", "").strip().upper() == "TRUE",
+                "default": row.get("default", "").strip() or None,
+            }
+    logger.info("Loaded schema with %d tables", len(schema))
+    return schema

--- a/modules/schema/schema_syncer.py
+++ b/modules/schema/schema_syncer.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+"""Synchronize schema definitions between CSV and Directus."""
+
+import logging
+from typing import Any, Dict
+
+from modules.api.directus_client import DirectusClient
+from .schema_loader import load_schema
+from .schema_exporter import fetch_schema
+
+logger = logging.getLogger(__name__)
+
+
+def _fields_equal(csv_def: Dict[str, Any], directus_def: Dict[str, Any]) -> bool:
+    """Return ``True`` if ``csv_def`` matches ``directus_def``."""
+    def norm(val: Any) -> Any:
+        if val is None:
+            return None
+        if isinstance(val, str):
+            return val.strip()
+        return val
+
+    return (
+        norm(csv_def.get("type")) == norm(directus_def.get("type"))
+        and norm(csv_def.get("precision")) == norm(directus_def.get("precision"))
+        and norm(csv_def.get("scale")) == norm(directus_def.get("scale"))
+        and bool(csv_def.get("required"))
+        == (not directus_def.get("schema", {}).get("is_nullable", True))
+        and norm(csv_def.get("default")) == norm(directus_def.get("default_value"))
+    )
+
+
+def sync_schema(
+    csv_path: str | None = None,
+    client: DirectusClient | None = None,
+    *,
+    remove_extra: bool = False,
+) -> None:
+    """Synchronize ``csv_path`` definitions with Directus."""
+    client = client or DirectusClient()
+    csv_schema = load_schema(csv_path or "config/schema_definitions.csv")
+    directus_schema = fetch_schema(client)
+
+    # CSV -> Directus
+    for table, fields in csv_schema.items():
+        d_fields = directus_schema.get(table, {})
+        for field, csv_def in fields.items():
+            if field in d_fields:
+                if not _fields_equal(csv_def, d_fields[field]):
+                    client.update_field(table, field, csv_def)
+                    logger.info("[SYNC][UPDATE] %s.%s", table, field)
+                else:
+                    logger.debug("[SYNC][SKIP] %s.%s", table, field)
+            else:
+                client.create_field(table, field, csv_def)
+                logger.info("[SYNC][CREATE] %s.%s", table, field)
+
+    # Handle extra fields
+    if remove_extra:
+        for table, fields in directus_schema.items():
+            if table in csv_schema:
+                for field in fields:
+                    if field not in csv_schema[table]:
+                        client.delete_field(table, field)
+                        logger.info("[SYNC][DELETE] %s.%s", table, field)


### PR DESCRIPTION
## Summary
- add schema definition CSV
- implement Directus API wrapper in `modules/api`
- implement schema loader, exporter and syncer modules
- provide command line entry point `main.py`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6842e7aa04148327ae8a9172e8d169a5