### PR TITLE
Add package entry point

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,8 +51,9 @@ whenever data is requested. See [docs/configuration.md](docs/configuration.md) f
 ## Quick Start
 Run the interactive menu:
 ```bash
-python scripts/main.py
+python -m modules
 ```
+The legacy entry point `python scripts/main.py` continues to work as well.
 Manage your portfolio:
 ```bash
 python scripts/main.py portfolio

--- a/modules/__main__.py
+++ b/modules/__main__.py
@@ -1,0 +1,10 @@
+"""Fundalyze command line entry point.
+
+Running ``python -m modules`` launches the same interactive menu as
+``python scripts/main.py``. This small wrapper allows the application to be
+invoked as a package without relying on the scripts directory.
+"""
+from scripts.main import main
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- allow launching the CLI with `python -m modules`
- document new entry point in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6842f11127848327ad406e7169df101b