### PR TITLE
Fix schema export when Directus schema missing

### DIFF
--- a/modules/schema/schema_exporter.py
+++ b/modules/schema/schema_exporter.py
@@ -46,7 +46,7 @@ def export_schema(client: DirectusClient, output: str | Path) -> None:
                     "type": f.get("type"),
                     "precision": f.get("precision"),
                     "scale": f.get("scale"),
-                    "required": not f.get("schema", {}).get("is_nullable", True),
+                    "required": not (f.get("schema") or {}).get("is_nullable", True),
                     "default": f.get("default_value"),
                 }
             )

--- a/modules/schema/schema_syncer.py
+++ b/modules/schema/schema_syncer.py
@@ -26,7 +26,7 @@ def _fields_equal(csv_def: Dict[str, Any], directus_def: Dict[str, Any]) -> bool
         and norm(csv_def.get("precision")) == norm(directus_def.get("precision"))
         and norm(csv_def.get("scale")) == norm(directus_def.get("scale"))
         and bool(csv_def.get("required"))
-        == (not directus_def.get("schema", {}).get("is_nullable", True))
+        == (not (directus_def.get("schema") or {}).get("is_nullable", True))
         and norm(csv_def.get("default")) == norm(directus_def.get("default_value"))
     )
 


### PR DESCRIPTION
### Summary
- prevent crashes when Directus fields contain `"schema": null`
- adjust equality check accordingly

### Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6842f97a255c8327a162304f84c38dee